### PR TITLE
feat: publish versioned REST and OpenAPI contracts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,11 @@ SPRING_DATASOURCE_PASSWORD=granthalay ./mvnw spring-boot:run
 ```
 
 The API defaults to `http://localhost:8080`. Health probes are available under `/actuator/health`.
-Swagger UI and other routes remain denied until their access policies are introduced.
+API discovery is available at `/api/v1`, the OpenAPI source of truth at
+`/openapi/granthalay-api-v1.yaml`; dynamic Springdoc and Swagger UI routes remain denied.
+
+`./mvnw generate-test-resources` validates the OpenAPI document and generates a Fetch-based
+TypeScript client under `target/generated-clients/typescript`.
 
 ## Validate a change
 

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -9,7 +9,8 @@ one application and one PostgreSQL database with explicit module ownership.
 The backend foundation has verified module boundaries, Flyway-managed infrastructure tables,
 restricted health probes, and a separately deployable container. CI checks Java formatting, unit and
 module tests, PostgreSQL integration tests, and container startup; pull requests also receive dependency
-review. Public API endpoints and product use cases are not implemented yet.
+review. The versioned API contract and discovery endpoint are published; product use cases are not
+implemented yet.
 
 ## Technology
 

--- a/docs/api-conventions.md
+++ b/docs/api-conventions.md
@@ -1,10 +1,10 @@
 # API conventions
 
-These rules apply as HTTP endpoints are introduced.
-
-The foundation has no public `/api/v1` endpoints yet. Only GET health, liveness, and readiness probes
-under `/actuator/health` are accessible. Other routes, including OpenAPI and Swagger UI, return a
-generic 403 Problem Details response until their access policies are explicitly introduced.
+This document defines the HTTP compatibility policy. The machine-readable source of truth is
+[`src/main/resources/static/openapi/granthalay-api-v1.yaml`](../src/main/resources/static/openapi/granthalay-api-v1.yaml).
+The running application publishes that exact document at `/openapi/granthalay-api-v1.yaml` and links
+to it from `GET /api/v1`. Dynamic Springdoc and Swagger UI routes remain private so there is only one
+public contract document.
 
 ## URLs and media types
 
@@ -12,26 +12,49 @@ generic 403 Problem Details response until their access policies are explicitly 
 - Use plural resource nouns and standard HTTP semantics.
 - JSON is the default representation; file delivery uses an explicit safe content type.
 - Pagination uses bounded `page` and `size` parameters until a cursor contract is required.
-- OpenAPI is generated from the running application and updated with contract changes.
+- Request and response bodies use transport DTOs. Persistence entities must never cross the HTTP
+  boundary; `HttpBoundaryTests` enforces this for controller signatures.
+- Optional request fields are distinguishable from explicit `null` where those meanings differ.
+- Success responses document every status, media type, and body. `204 No Content` has no body.
+- The `Location` header identifies a newly created resource after a successful `201 Created`.
+
+## Pagination
+
+Collection endpoints use the reusable OpenAPI `Page` and `Size` parameters and return their items
+with `PageMetadata`. `page` is zero-based, `size` is between 1 and 100, and stable sorting must be
+documented by each operation. Pagination may move to an opaque cursor in a future API version when
+offset pagination is no longer safe or efficient.
 
 ## Errors
 
-Use RFC 9457 Problem Details (`application/problem+json`). A response should include a stable
-machine-readable problem type, status, human-readable title, and safe detail. Validation failures
-identify invalid fields without leaking rejected secrets or internal implementation details.
+Failures use RFC 9457 Problem Details (`application/problem+json`). `type` and validation `code`
+values are stable machine-readable identifiers; `title` and `detail` are safe human-readable text.
+Validation failures use `ValidationProblem.errors` with `field`, `code`, and `message`, never the
+rejected value. Authentication and authorization failures use the same media type and do not reveal
+whether an account or protected resource exists. A safe `requestId` may be returned for support.
 
 ## Compatibility
 
 Additive response fields are backward compatible; clients must ignore fields they do not recognize.
 Removing or renaming fields, changing meaning, or tightening accepted input requires a new API
-version or a documented migration window.
+`ApiContractCompatibilityTests` compares the published v1 contract with its committed compatibility
+baseline. When intentionally expanding the contract, update the source document first and then the
+baseline. A breaking v1 change must not update the baseline; introduce a new API version instead.
+
+Maven generates a Fetch-based TypeScript client into `target/generated-clients/typescript` during
+`generate-test-resources`, so `verify` proves that the published contract remains generator-compatible.
 
 ## Authentication and browser access
 
 Public catalog endpoints may be anonymous. Account, order, entitlement, delivery, publisher, and
-administrative endpoints require explicit authorization. CORS permits only configured Granthalay
-origins and the minimum required methods and headers. Never place credentials or access tokens in
-URLs.
+administrative endpoints require explicit authorization. Browser sessions use the `SESSION` cookie;
+non-browser clients may use bearer credentials when an operation declares that scheme. Never place
+credentials or access tokens in URLs.
+
+CORS applies only below `/api/**`, permits credentialed requests only from the comma-separated
+`GRANTHALAY_WEB_ALLOWED_ORIGINS` configuration, and never uses a wildcard origin. Allowed request
+headers are `Accept`, `Content-Type`, `Authorization`, and `X-Request-ID`; exposed response headers
+are `Location` and `X-Request-ID`.
 
 ## Observability
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,12 +65,16 @@ Logs are structured and redact credentials, tokens, payment data, book contents,
 Reading telemetry is not collected by default. Database migrations are forward-only after release,
 and uploaded content is treated as untrusted input.
 
-Only anonymous GET requests to `/actuator/health`, `/actuator/health/liveness`, and
-`/actuator/health/readiness` are permitted in the foundation. Probes expose status only; root health
-also lists the two probe groups. Readiness includes database connectivity and application availability;
-liveness does not depend on the database. Other routes return generic 403 Problem Details.
+Anonymous GET requests are limited to `/actuator/health`, `/actuator/health/liveness`,
+`/actuator/health/readiness`, `/api/v1`, and the published v1 OpenAPI document. Probes expose status
+only; root health also lists the two probe groups. Readiness includes database connectivity and
+application availability; liveness does not depend on the database. Other routes return generic 403
+Problem Details.
 There is no default account or generated password, denied requests are not saved in sessions,
 and CSRF protection remains enabled. Product endpoints require explicit access policies as introduced.
+
+Credentialed CORS is scoped to `/api/**`. Origins come from
+`GRANTHALAY_WEB_ALLOWED_ORIGINS`; wildcard origins are not accepted.
 
 ## Repository relationship
 

--- a/pom.xml
+++ b/pom.xml
@@ -181,11 +181,6 @@
 			<artifactId>testcontainers-postgresql</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.yaml</groupId>
-			<artifactId>snakeyaml</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,11 @@
 			<artifactId>testcontainers-postgresql</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.yaml</groupId>
+			<artifactId>snakeyaml</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>
@@ -196,6 +201,30 @@
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.openapitools</groupId>
+				<artifactId>openapi-generator-maven-plugin</artifactId>
+				<version>7.24.0</version>
+				<executions>
+					<execution>
+						<id>generate-typescript-client</id>
+						<phase>generate-test-resources</phase>
+						<goals>
+							<goal>generate</goal>
+						</goals>
+						<configuration>
+							<inputSpec>${project.basedir}/src/main/resources/static/openapi/granthalay-api-v1.yaml</inputSpec>
+							<generatorName>typescript-fetch</generatorName>
+							<output>${project.build.directory}/generated-clients/typescript</output>
+							<configOptions>
+								<npmName>@granthalay/api-client</npmName>
+								<supportsES6>true</supportsES6>
+								<useSingleRequestParameter>true</useSingleRequestParameter>
+							</configOptions>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>io.spring.javaformat</groupId>
 				<artifactId>spring-javaformat-maven-plugin</artifactId>

--- a/scripts/check-container.py
+++ b/scripts/check-container.py
@@ -52,7 +52,10 @@ def main():
         deadline = time.monotonic() + 60
         while True:
             if run([args.engine, "inspect", "--format", "{{.State.Running}}", application]) != "true":
-                raise RuntimeError("Application container exited before becoming ready")
+                logs = run([args.engine, "logs", application])
+                raise RuntimeError(
+                    "Application container exited before becoming ready:\n" + logs
+                )
             try:
                 if health(port, "/actuator/health/readiness") == (200, {"status": "UP"}):
                     break

--- a/src/main/java/dev/samster/granthalay/operations/ApiIndexController.java
+++ b/src/main/java/dev/samster/granthalay/operations/ApiIndexController.java
@@ -1,0 +1,14 @@
+package dev.samster.granthalay.operations;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class ApiIndexController {
+
+	@GetMapping("/api/v1")
+	ApiIndexResponse index() {
+		return new ApiIndexResponse("Granthalay API", "v1", "/openapi/granthalay-api-v1.yaml");
+	}
+
+}

--- a/src/main/java/dev/samster/granthalay/operations/ApiIndexResponse.java
+++ b/src/main/java/dev/samster/granthalay/operations/ApiIndexResponse.java
@@ -1,0 +1,4 @@
+package dev.samster.granthalay.operations;
+
+record ApiIndexResponse(String name, String version, String openapi) {
+}

--- a/src/main/java/dev/samster/granthalay/operations/SecurityConfiguration.java
+++ b/src/main/java/dev/samster/granthalay/operations/SecurityConfiguration.java
@@ -2,15 +2,21 @@ package dev.samster.granthalay.operations;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration(proxyBeanMethods = false)
 class SecurityConfiguration {
@@ -19,9 +25,10 @@ class SecurityConfiguration {
 	SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		return http.requestCache(cache -> cache.disable())
 			.logout(logout -> logout.disable())
+			.cors(Customizer.withDefaults())
 			.authorizeHttpRequests(requests -> requests
 				.requestMatchers(HttpMethod.GET, "/actuator/health", "/actuator/health/liveness",
-						"/actuator/health/readiness")
+						"/actuator/health/readiness", "/api/v1", "/openapi/granthalay-api-v1.yaml")
 				.permitAll()
 				.anyRequest()
 				.denyAll())
@@ -29,6 +36,21 @@ class SecurityConfiguration {
 					errors -> errors.authenticationEntryPoint((request, response, exception) -> forbidden(response))
 						.accessDeniedHandler((request, response, exception) -> forbidden(response)))
 			.build();
+	}
+
+	@Bean
+	CorsConfigurationSource corsConfigurationSource(
+			@Value("${granthalay.web.allowed-origins}") List<String> allowedOrigins) {
+		var configuration = new CorsConfiguration();
+		configuration.setAllowedOrigins(allowedOrigins);
+		configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+		configuration.setAllowedHeaders(List.of("Accept", "Content-Type", "Authorization", "X-Request-ID"));
+		configuration.setExposedHeaders(List.of("Location", "X-Request-ID"));
+		configuration.setAllowCredentials(true);
+		configuration.setMaxAge(3600L);
+		var source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/api/**", configuration);
+		return source;
 	}
 
 	@Bean

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,7 +19,6 @@ spring:
   mvc:
     problemdetails:
       enabled: true
-
 management:
   endpoints:
     web:
@@ -40,3 +39,7 @@ server:
     include-message: never
     include-stacktrace: never
     include-binding-errors: never
+
+granthalay:
+  web:
+    allowed-origins: ${GRANTHALAY_WEB_ALLOWED_ORIGINS:https://samsterzero.github.io}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,6 +19,11 @@ spring:
   mvc:
     problemdetails:
       enabled: true
+  web:
+    error:
+      include-binding-errors: never
+      include-message: never
+      include-stacktrace: never
 management:
   endpoints:
     web:
@@ -33,12 +38,6 @@ management:
       group:
         readiness:
           include: readinessState,db
-
-server:
-  error:
-    include-message: never
-    include-stacktrace: never
-    include-binding-errors: never
 
 granthalay:
   web:

--- a/src/main/resources/static/openapi/granthalay-api-v1.yaml
+++ b/src/main/resources/static/openapi/granthalay-api-v1.yaml
@@ -1,0 +1,157 @@
+openapi: 3.1.0
+info:
+  title: Granthalay API
+  version: v1
+  description: |-
+    Contract for optional connected Granthalay features. The local-only reader does not depend on
+    this API. New fields may be added to responses without a version change; clients must ignore
+    unknown fields. Removing or renaming fields, changing their meaning, or tightening accepted
+    input requires a new API version or a documented migration window.
+servers:
+  - url: /
+tags:
+  - name: Contract
+    description: API discovery and contract metadata.
+paths:
+  /api/v1:
+    get:
+      tags: [Contract]
+      operationId: getApiIndex
+      summary: Discover the current API contract
+      security: []
+      responses:
+        '200':
+          description: Version and OpenAPI document location.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiIndex'
+        '500':
+          $ref: '#/components/responses/Problem'
+components:
+  securitySchemes:
+    sessionCookie:
+      type: apiKey
+      in: cookie
+      name: SESSION
+      description: Revocable browser session. Browser requests include credentials.
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  parameters:
+    Page:
+      name: page
+      in: query
+      description: Zero-based page number.
+      schema:
+        type: integer
+        format: int32
+        minimum: 0
+        default: 0
+    Size:
+      name: size
+      in: query
+      description: Requested page size, capped by the endpoint.
+      schema:
+        type: integer
+        format: int32
+        minimum: 1
+        maximum: 100
+        default: 20
+  responses:
+    Problem:
+      description: Request failed.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+    ValidationProblem:
+      description: Request validation failed.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ValidationProblem'
+  schemas:
+    ApiIndex:
+      type: object
+      additionalProperties: false
+      required: [name, version, openapi]
+      properties:
+        name:
+          type: string
+          example: Granthalay API
+        version:
+          type: string
+          const: v1
+        openapi:
+          type: string
+          format: uri-reference
+          example: /openapi/granthalay-api-v1.yaml
+    PageMetadata:
+      type: object
+      additionalProperties: false
+      required: [page, size, totalElements, totalPages]
+      properties:
+        page:
+          type: integer
+          format: int32
+          minimum: 0
+        size:
+          type: integer
+          format: int32
+          minimum: 1
+        totalElements:
+          type: integer
+          format: int64
+          minimum: 0
+        totalPages:
+          type: integer
+          format: int32
+          minimum: 0
+    Problem:
+      type: object
+      required: [type, title, status]
+      properties:
+        type:
+          type: string
+          format: uri-reference
+          default: about:blank
+        title:
+          type: string
+        status:
+          type: integer
+          format: int32
+          minimum: 400
+          maximum: 599
+        detail:
+          type: string
+        instance:
+          type: string
+          format: uri-reference
+        requestId:
+          type: string
+          description: Safe correlation identifier when one is available.
+    ValidationProblem:
+      allOf:
+        - $ref: '#/components/schemas/Problem'
+        - type: object
+          required: [errors]
+          properties:
+            errors:
+              type: array
+              items:
+                $ref: '#/components/schemas/FieldError'
+    FieldError:
+      type: object
+      additionalProperties: false
+      required: [field, code, message]
+      properties:
+        field:
+          type: string
+        code:
+          type: string
+          description: Stable machine-readable validation code.
+        message:
+          type: string
+          description: Safe human-readable explanation; rejected values are omitted.

--- a/src/test/java/dev/samster/granthalay/ApiContractCompatibilityTests.java
+++ b/src/test/java/dev/samster/granthalay/ApiContractCompatibilityTests.java
@@ -1,0 +1,68 @@
+package dev.samster.granthalay;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApiContractCompatibilityTests {
+
+	@Test
+	void publishedContractDoesNotBreakTheV1Baseline() throws IOException {
+		var current = load("/static/openapi/granthalay-api-v1.yaml");
+		var baseline = load("/openapi/granthalay-api-v1-baseline.yaml");
+
+		var currentPaths = map(current.get("paths"));
+		map(baseline.get("paths")).forEach((path, baselinePathValue) -> {
+			assertThat(currentPaths).as("published path %s", path).containsKey(path);
+			var currentPath = map(currentPaths.get(path));
+			map(baselinePathValue).forEach((method, baselineOperationValue) -> {
+				assertThat(currentPath).as("operation %s %s", method, path).containsKey(method);
+				var currentResponses = map(map(currentPath.get(method)).get("responses"));
+				var baselineResponses = map(map(baselineOperationValue).get("responses"));
+				assertThat(currentResponses.keySet()).as("responses for %s %s", method, path)
+					.containsAll(baselineResponses.keySet());
+			});
+		});
+
+		var currentSchemas = map(map(current.get("components")).get("schemas"));
+		map(map(baseline.get("components")).get("schemas")).forEach((name, baselineSchemaValue) -> {
+			assertThat(currentSchemas).as("schema %s", name).containsKey(name);
+			var currentSchema = map(currentSchemas.get(name));
+			var baselineSchema = map(baselineSchemaValue);
+			assertThat(list(currentSchema.get("required"))).as("required properties of %s", name)
+				.containsAll(list(baselineSchema.get("required")));
+			var currentProperties = map(currentSchema.get("properties"));
+			map(baselineSchema.get("properties")).forEach((property, baselinePropertyValue) -> {
+				assertThat(currentProperties).as("property %s.%s", name, property).containsKey(property);
+				var currentProperty = map(currentProperties.get(property));
+				map(baselinePropertyValue).forEach((constraint, value) -> assertThat(currentProperty.get(constraint))
+					.as("%s.%s %s", name, property, constraint)
+					.isEqualTo(value));
+			});
+		});
+	}
+
+	private Map<String, Object> load(String resource) throws IOException {
+		try (InputStream input = getClass().getResourceAsStream(resource)) {
+			assertThat(input).as("contract resource %s", resource).isNotNull();
+			return map(new Yaml().load(input));
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Map<String, Object> map(Object value) {
+		return value == null ? Map.of() : (Map<String, Object>) value;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static List<String> list(Object value) {
+		return value == null ? List.of() : (List<String>) value;
+	}
+
+}

--- a/src/test/java/dev/samster/granthalay/ApiContractIT.java
+++ b/src/test/java/dev/samster/granthalay/ApiContractIT.java
@@ -36,8 +36,7 @@ class ApiContractIT {
 	@Test
 	void allowsCredentialedCorsOnlyForConfiguredOrigins() throws Exception {
 		var allowed = request("/api/v1", "https://reader.example");
-		assertThat(allowed.headers().firstValue("Access-Control-Allow-Origin"))
-			.hasValue("https://reader.example");
+		assertThat(allowed.headers().firstValue("Access-Control-Allow-Origin")).hasValue("https://reader.example");
 		assertThat(allowed.headers().firstValue("Access-Control-Allow-Credentials")).hasValue("true");
 
 		var denied = request("/api/v1", "https://attacker.example");

--- a/src/test/java/dev/samster/granthalay/ApiContractIT.java
+++ b/src/test/java/dev/samster/granthalay/ApiContractIT.java
@@ -1,0 +1,58 @@
+package dev.samster.granthalay;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+		properties = "granthalay.web.allowed-origins=https://reader.example")
+class ApiContractIT {
+
+	@LocalServerPort
+	int port;
+
+	@Test
+	void publishesVersionedIndexAndOpenApiSourceOfTruth() throws Exception {
+		var index = request("/api/v1", null);
+		assertThat(index.statusCode()).isEqualTo(200);
+		assertThat(index.headers().firstValue("Content-Type")).hasValue("application/json");
+		assertThat(index.body()).isEqualTo(
+				"{\"name\":\"Granthalay API\",\"version\":\"v1\",\"openapi\":\"/openapi/granthalay-api-v1.yaml\"}");
+
+		var contract = request("/openapi/granthalay-api-v1.yaml", null);
+		assertThat(contract.statusCode()).isEqualTo(200);
+		assertThat(contract.body()).contains("openapi: 3.1.0", "  /api/v1:");
+	}
+
+	@Test
+	void allowsCredentialedCorsOnlyForConfiguredOrigins() throws Exception {
+		var allowed = request("/api/v1", "https://reader.example");
+		assertThat(allowed.headers().firstValue("Access-Control-Allow-Origin"))
+			.hasValue("https://reader.example");
+		assertThat(allowed.headers().firstValue("Access-Control-Allow-Credentials")).hasValue("true");
+
+		var denied = request("/api/v1", "https://attacker.example");
+		assertThat(denied.headers().firstValue("Access-Control-Allow-Origin")).isEmpty();
+		assertThat(denied.headers().firstValue("Access-Control-Allow-Credentials")).isEmpty();
+	}
+
+	private HttpResponse<String> request(String path, String origin) throws Exception {
+		var builder = HttpRequest.newBuilder(URI.create("http://localhost:" + port + path)).GET();
+		if (origin != null) {
+			builder.header("Origin", origin);
+		}
+		try (var client = HttpClient.newHttpClient()) {
+			return client.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+		}
+	}
+
+}

--- a/src/test/java/dev/samster/granthalay/HttpBoundaryTests.java
+++ b/src/test/java/dev/samster/granthalay/HttpBoundaryTests.java
@@ -1,0 +1,54 @@
+package dev.samster.granthalay;
+
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import jakarta.persistence.Entity;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HttpBoundaryTests {
+
+	@Test
+	void restControllersNeverExposePersistenceEntities() throws ClassNotFoundException {
+		var scanner = new ClassPathScanningCandidateComponentProvider(false);
+		scanner.addIncludeFilter(new AnnotationTypeFilter(RestController.class));
+		for (var candidate : scanner.findCandidateComponents("dev.samster.granthalay")) {
+			var controller = Class.forName(candidate.getBeanClassName());
+			for (var method : controller.getDeclaredMethods()) {
+				var boundaryTypes = Stream.concat(Stream.of(method.getGenericReturnType()),
+						Arrays.stream(method.getGenericParameterTypes()));
+				assertThat(boundaryTypes).as("HTTP types used by %s#%s", controller.getName(), method.getName())
+					.noneMatch(HttpBoundaryTests::containsEntity);
+			}
+		}
+	}
+
+	private static boolean containsEntity(Type type) {
+		if (type instanceof Class<?> candidate) {
+			return candidate.isAnnotationPresent(Entity.class)
+					|| candidate.isArray() && containsEntity(candidate.componentType());
+		}
+		if (type instanceof ParameterizedType parameterized) {
+			return containsEntity(parameterized.getRawType())
+					|| Arrays.stream(parameterized.getActualTypeArguments()).anyMatch(HttpBoundaryTests::containsEntity);
+		}
+		if (type instanceof GenericArrayType array) {
+			return containsEntity(array.getGenericComponentType());
+		}
+		if (type instanceof WildcardType wildcard) {
+			return Stream.concat(Arrays.stream(wildcard.getLowerBounds()), Arrays.stream(wildcard.getUpperBounds()))
+				.anyMatch(HttpBoundaryTests::containsEntity);
+		}
+		return false;
+	}
+
+}

--- a/src/test/java/dev/samster/granthalay/HttpBoundaryTests.java
+++ b/src/test/java/dev/samster/granthalay/HttpBoundaryTests.java
@@ -24,29 +24,35 @@ class HttpBoundaryTests {
 		for (var candidate : scanner.findCandidateComponents("dev.samster.granthalay")) {
 			var controller = Class.forName(candidate.getBeanClassName());
 			for (var method : controller.getDeclaredMethods()) {
-				var boundaryTypes = Stream.concat(Stream.of(method.getGenericReturnType()),
-						Arrays.stream(method.getGenericParameterTypes()));
-				assertThat(boundaryTypes).as("HTTP types used by %s#%s", controller.getName(), method.getName())
-					.noneMatch(HttpBoundaryTests::containsEntity);
+				var returnType = Stream.of(method.getGenericReturnType());
+				var parameterTypes = Arrays.stream(method.getGenericParameterTypes());
+				var boundaryTypes = Stream.concat(returnType, parameterTypes);
+				var description = "HTTP types used by %s#%s".formatted(controller.getName(), method.getName());
+				assertThat(boundaryTypes).as(description).noneMatch(HttpBoundaryTests::containsEntity);
 			}
 		}
 	}
 
 	private static boolean containsEntity(Type type) {
 		if (type instanceof Class<?> candidate) {
-			return candidate.isAnnotationPresent(Entity.class)
-					|| candidate.isArray() && containsEntity(candidate.componentType());
+			if (candidate.isAnnotationPresent(Entity.class)) {
+				return true;
+			}
+			return candidate.isArray() && containsEntity(candidate.componentType());
 		}
 		if (type instanceof ParameterizedType parameterized) {
-			return containsEntity(parameterized.getRawType())
-					|| Arrays.stream(parameterized.getActualTypeArguments()).anyMatch(HttpBoundaryTests::containsEntity);
+			if (containsEntity(parameterized.getRawType())) {
+				return true;
+			}
+			return Arrays.stream(parameterized.getActualTypeArguments()).anyMatch(HttpBoundaryTests::containsEntity);
 		}
 		if (type instanceof GenericArrayType array) {
 			return containsEntity(array.getGenericComponentType());
 		}
 		if (type instanceof WildcardType wildcard) {
-			return Stream.concat(Arrays.stream(wildcard.getLowerBounds()), Arrays.stream(wildcard.getUpperBounds()))
-				.anyMatch(HttpBoundaryTests::containsEntity);
+			var lowerBounds = Arrays.stream(wildcard.getLowerBounds());
+			var upperBounds = Arrays.stream(wildcard.getUpperBounds());
+			return Stream.concat(lowerBounds, upperBounds).anyMatch(HttpBoundaryTests::containsEntity);
 		}
 		return false;
 	}

--- a/src/test/resources/openapi/granthalay-api-v1-baseline.yaml
+++ b/src/test/resources/openapi/granthalay-api-v1-baseline.yaml
@@ -1,0 +1,64 @@
+openapi: 3.1.0
+paths:
+  /api/v1:
+    get:
+      responses:
+        '200': {}
+        '500': {}
+components:
+  schemas:
+    ApiIndex:
+      required: [name, version, openapi]
+      properties:
+        name:
+          type: string
+        version:
+          type: string
+        openapi:
+          type: string
+          format: uri-reference
+    PageMetadata:
+      required: [page, size, totalElements, totalPages]
+      properties:
+        page:
+          type: integer
+          format: int32
+        size:
+          type: integer
+          format: int32
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+          format: int32
+    Problem:
+      required: [type, title, status]
+      properties:
+        type:
+          type: string
+          format: uri-reference
+        title:
+          type: string
+        status:
+          type: integer
+          format: int32
+        detail:
+          type: string
+        instance:
+          type: string
+          format: uri-reference
+        requestId:
+          type: string
+    ValidationProblem:
+      required: []
+      properties: {}
+    FieldError:
+      required: [field, code, message]
+      properties:
+        field:
+          type: string
+        code:
+          type: string
+        message:
+          type: string


### PR DESCRIPTION
Closes #12

## Summary
- publish the versioned API discovery endpoint and committed OpenAPI 3.1 contract
- generate a TypeScript Fetch client from the published contract
- enforce compatibility baselines and prevent persistence entities from crossing HTTP boundaries
- restrict credentialed CORS to configured frontend origins
- document request, response, error, pagination, authentication, and compatibility conventions

## Verification
- Not run locally at the user request; GitHub CI will perform verification.