### PR TITLE
feat: Deploy the API safely to OCI Compute & Kubernetes (#18)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Granthalay API Environment Variables Template
+POSTGRES_DB=granthalay
+POSTGRES_USER=granthalay
+POSTGRES_PASSWORD=granthalay_change_me_in_prod
+
+SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/granthalay
+SPRING_DATASOURCE_USERNAME=granthalay
+SPRING_DATASOURCE_PASSWORD=granthalay_change_me_in_prod
+
+GRANTHALAY_WEB_ALLOWED_ORIGINS=https://samsterzero.github.io
+DOMAIN_NAME=localhost
+API_TAG=latest
+
+JAVA_TOOL_OPTIONS=-XX:MaxRAMPercentage=75.0 -XX:InitialRAMPercentage=50.0 -XX:+UseG1GC

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Validate Compose
         run: docker compose config --quiet
 
+      - name: Validate Kubernetes manifests
+        run: kubectl apply --dry-run=client -f k8s/
+
       - name: Build application image
         run: docker build -t granthalay-api:ci .
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
         run: docker compose config --quiet
 
       - name: Validate Kubernetes manifests
-        run: kubectl apply --dry-run=client -f k8s/
+        run: kubectl kustomize k8s/ > /dev/null
+
 
       - name: Build application image
         run: docker build -t granthalay-api:ci .

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,49 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Deployment target (kubernetes or compute)'
+        required: true
+        default: 'kubernetes'
+        type: choice
+        options:
+          - kubernetes
+          - compute
+      image_tag:
+        description: 'OCI container image tag (e.g. latest, sha-xxxxxxx, or v0.1.0)'
+        required: true
+        default: 'latest'
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: deploy-${{ inputs.target }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to OCI (${{ inputs.target }})
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Validate Kubernetes Manifests
+        if: inputs.target == 'kubernetes'
+        run: |
+          kubectl apply --dry-run=client -f k8s/
+
+      - name: Validate Docker Compose Configuration
+        if: inputs.target == 'compute'
+        run: |
+          docker compose config --quiet
+
+      - name: Log Deployment Action
+        run: |
+          echo "Deploying Granthalay API tag '${{ inputs.image_tag }}' to OCI ${{ inputs.target }} target."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,8 @@ jobs:
       - name: Validate Kubernetes Manifests
         if: inputs.target == 'kubernetes'
         run: |
-          kubectl apply --dry-run=client -f k8s/
+          kubectl kustomize k8s/ > /dev/null
+
 
       - name: Validate Docker Compose Configuration
         if: inputs.target == 'compute'

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,15 @@
+{$DOMAIN_NAME:localhost} {
+    reverse_proxy api:8080
+
+    header {
+        Strict-Transport-Security "max-age=31536000; includeSubDomains"
+        X-Content-Type-Options "nosniff"
+        X-Frame-Options "DENY"
+        Referrer-Policy "no-referrer-when-downgrade"
+    }
+
+    log {
+        output stdout
+        format json
+    }
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,18 +2,67 @@ services:
   postgres:
     image: 'docker.io/library/postgres:18-alpine'
     environment:
-      POSTGRES_DB: granthalay
-      POSTGRES_PASSWORD: granthalay
-      POSTGRES_USER: granthalay
-    ports:
-      - '5432:5432'
+      POSTGRES_DB: '${POSTGRES_DB:-granthalay}'
+      POSTGRES_PASSWORD: '${POSTGRES_PASSWORD:-granthalay}'
+      POSTGRES_USER: '${POSTGRES_USER:-granthalay}'
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U granthalay -d granthalay']
+      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER:-granthalay} -d ${POSTGRES_DB:-granthalay}']
       interval: 5s
       timeout: 5s
       retries: 10
     volumes:
       - postgres-data:/var/lib/postgresql
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+
+  api:
+    image: '${API_IMAGE:-ghcr.io/samsterzero/granthalayapi:latest}'
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      SPRING_DATASOURCE_URL: '${SPRING_DATASOURCE_URL:-jdbc:postgresql://postgres:5432/granthalay}'
+      SPRING_DATASOURCE_USERNAME: '${SPRING_DATASOURCE_USERNAME:-granthalay}'
+      SPRING_DATASOURCE_PASSWORD: '${SPRING_DATASOURCE_PASSWORD:-granthalay}'
+      GRANTHALAY_WEB_ALLOWED_ORIGINS: '${GRANTHALAY_WEB_ALLOWED_ORIGINS:-https://samsterzero.github.io}'
+      JAVA_TOOL_OPTIONS: '${JAVA_TOOL_OPTIONS:--XX:MaxRAMPercentage=75.0 -XX:InitialRAMPercentage=50.0 -XX:+UseG1GC}'
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ['CMD-SHELL', 'wget --no-verbose --tries=1 --spider http://localhost:8080/actuator/health/readiness || exit 1']
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 20s
+    deploy:
+      resources:
+        limits:
+          memory: 768M
+
+  caddy:
+    image: 'docker.io/library/caddy:2-alpine'
+    restart: unless-stopped
+    ports:
+      - '80:80'
+      - '443:443'
+    environment:
+      DOMAIN_NAME: '${DOMAIN_NAME:-localhost}'
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    depends_on:
+      api:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          memory: 128M
 
 volumes:
   postgres-data:
+  caddy-data:
+  caddy-config:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,9 +17,8 @@ notifications, publisher operations, administration, and auditing.
 
 ## Deployment model
 
-The backend is a Spring Modulith modular monolith. It is built as one OCI image and deployed
-separately from the GitHub Pages frontend. Initially, modules share one PostgreSQL instance but own
-their schemas or tables. External providers are replaceable adapters at the application boundary.
+The backend is a Spring Modulith modular monolith. It is built as a multi-architecture OCI image (`linux/amd64`, `linux/arm64`) and deployed separately from the GitHub Pages frontend. Deployment targets include OCI Kubernetes (OKE) via `k8s/` manifests and OCI Compute VMs via `compose.yaml`. Public ingress is restricted to HTTPS; PostgreSQL and Spring Boot containers run on private internal networks. Complete deployment, secret rotation, and rollback procedures are documented in [docs/deployment.md](deployment.md).
+
 
 ## Module rules
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,115 @@
+# OCI Deployment Guide
+
+This document defines the production deployment topology and operations for **Granthalay API** on **Oracle Cloud Infrastructure (OCI)**. It supports both **OCI Kubernetes (OKE)** clusters and **OCI Compute** virtual machines (ARM64 Ampere & AMD64 free-tier instances).
+
+---
+
+## Topology & Network Security
+
+```
+[ Public HTTPS Internet ]
+           │
+           ▼
+ [ Ingress Controller / Caddy Proxy (TLS Port 443) ]
+           │
+           ▼ (Internal Network / ClusterIP)
+ [ Granthalay API (Spring Boot - Port 8080) ]
+           │
+           ▼ (Private Network / ClusterIP)
+ [ PostgreSQL Database (Port 5432) ]
+```
+
+1. **Public Interface**: Only HTTPS (`443`) and HTTP-to-HTTPS redirect (`80`) are exposed to the public internet via the Ingress Controller (OKE) or Caddy Reverse Proxy (Compute VM).
+2. **Private Services**: PostgreSQL (`5432`) and Spring Boot (`8080`) are strictly internal, reachable only inside the Kubernetes cluster or Docker Compose network.
+3. **Non-Root Execution**: The application OCI container runs as non-root user `granthalay`.
+
+---
+
+## 1. Deploying to OCI Kubernetes (OKE)
+
+The `k8s/` directory contains Kubernetes manifests tailored for OCI OKE:
+
+- `k8s/configmap-secret.yaml`: Application ConfigMap & Secret.
+- `k8s/postgres-statefulset.yaml`: PostgreSQL 18 StatefulSet + PersistentVolumeClaim + ClusterIP Service.
+- `k8s/api-deployment.yaml`: Spring Boot API Deployment + ClusterIP Service + Health Probes.
+- `k8s/ingress.yaml`: HTTPS Ingress resource.
+
+### Applying Manifests
+
+```bash
+# 1. Create or update secrets and configmap
+kubectl apply -f k8s/configmap-secret.yaml
+
+# 2. Deploy PostgreSQL database
+kubectl apply -f k8s/postgres-statefulset.yaml
+
+# 3. Deploy API application
+kubectl apply -f k8s/api-deployment.yaml
+
+# 4. Deploy Ingress routing
+kubectl apply -f k8s/ingress.yaml
+```
+
+### Rollback on OKE
+
+To roll back to the previous deployment version:
+
+```bash
+kubectl rollout undo deployment/granthalay-api
+```
+
+To view deployment status and history:
+
+```bash
+kubectl rollout status deployment/granthalay-api
+kubectl rollout history deployment/granthalay-api
+```
+
+---
+
+## 2. Deploying to OCI Compute (Docker Compose)
+
+For standalone OCI Compute instances (VMs):
+
+### Initial Setup
+
+1. Copy `.env.example` to `.env` on the host:
+   ```bash
+   cp .env.example .env
+   ```
+2. Edit `.env` to configure production secrets, allowed origins, and target domain name.
+
+3. Start services:
+   ```bash
+   docker compose up -d
+   ```
+
+### Rollback on OCI Compute
+
+To roll back to a specific image tag (e.g. `v0.1.0` or a short commit SHA):
+
+```bash
+# Set API_IMAGE in .env or via environment
+export API_IMAGE=ghcr.io/samsterzero/granthalayapi:sha-xxxxxxx
+docker compose up -d api
+```
+
+---
+
+## Secret Management & Rotation
+
+- **Credentials & Tokens**: Database passwords, session keys, and allowed origins are injected via environment variables outside of source control (`k8s/configmap-secret.yaml` in K8s, `.env` in Compose).
+- **Rotation**:
+  - Update password in Secret / `.env`.
+  - Update PostgreSQL user password in database.
+  - Restart API pods/containers (`kubectl rollout restart deployment/granthalay-api` or `docker compose restart api`).
+
+---
+
+## Resource Optimization for OCI Free Tier
+
+- **JVM RAM Tuning**: Set `JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=75.0 -XX:InitialRAMPercentage=50.0 -XX:+UseG1GC"` to prevent OOM errors on limited memory instances.
+- **Container Limits**:
+  - `granthalay-api`: Request 384Mi, Limit 768Mi.
+  - `postgres`: Request 256Mi, Limit 512Mi.
+  - `caddy`: Request 64Mi, Limit 128Mi.

--- a/k8s/api-deployment.yaml
+++ b/k8s/api-deployment.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: granthalay-api
+  labels:
+    app.kubernetes.io/name: granthalay-api
+    app.kubernetes.io/part-of: granthalay
+spec:
+  ports:
+    - port: 8080
+      targetPort: 8080
+      name: http
+  selector:
+    app.kubernetes.io/name: granthalay-api
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: granthalay-api
+  labels:
+    app.kubernetes.io/name: granthalay-api
+    app.kubernetes.io/part-of: granthalay
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: granthalay-api
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: granthalay-api
+        app.kubernetes.io/part-of: granthalay
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: granthalay-api
+          image: ghcr.io/samsterzero/granthalayapi:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              name: http
+          envFrom:
+            - configMapRef:
+                name: granthalay-config
+          env:
+            - name: SPRING_DATASOURCE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: granthalay-secret
+                  key: SPRING_DATASOURCE_USERNAME
+            - name: SPRING_DATASOURCE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: granthalay-secret
+                  key: SPRING_DATASOURCE_PASSWORD
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 15
+          resources:
+            requests:
+              memory: "384Mi"
+              cpu: "250m"
+            limits:
+              memory: "768Mi"
+              cpu: "1000m"

--- a/k8s/configmap-secret.yaml
+++ b/k8s/configmap-secret.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: granthalay-config
+  labels:
+    app.kubernetes.io/name: granthalay-api
+    app.kubernetes.io/part-of: granthalay
+data:
+  SPRING_DATASOURCE_URL: "jdbc:postgresql://postgres:5432/granthalay"
+  GRANTHALAY_WEB_ALLOWED_ORIGINS: "https://samsterzero.github.io"
+  JAVA_TOOL_OPTIONS: "-XX:MaxRAMPercentage=75.0 -XX:InitialRAMPercentage=50.0 -XX:+UseG1GC"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: granthalay-secret
+  labels:
+    app.kubernetes.io/name: granthalay-api
+    app.kubernetes.io/part-of: granthalay
+type: Opaque
+stringData:
+  POSTGRES_DB: "granthalay"
+  POSTGRES_USER: "granthalay"
+  POSTGRES_PASSWORD: "granthalay_change_me_in_prod"
+  SPRING_DATASOURCE_USERNAME: "granthalay"
+  SPRING_DATASOURCE_PASSWORD: "granthalay_change_me_in_prod"

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: granthalay-api-ingress
+  labels:
+    app.kubernetes.io/name: granthalay-api
+    app.kubernetes.io/part-of: granthalay
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+spec:
+  tls:
+    - hosts:
+        - api.granthalay.app
+      secretName: granthalay-api-tls
+  rules:
+    - host: api.granthalay.app
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: granthalay-api
+                port:
+                  number: 8080

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - configmap-secret.yaml
+  - postgres-statefulset.yaml
+  - api-deployment.yaml
+  - ingress.yaml

--- a/k8s/postgres-statefulset.yaml
+++ b/k8s/postgres-statefulset.yaml
@@ -1,0 +1,94 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/part-of: granthalay
+spec:
+  ports:
+    - port: 5432
+      targetPort: 5432
+      name: postgres
+  selector:
+    app.kubernetes.io/name: postgres
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/part-of: granthalay
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres
+        app.kubernetes.io/part-of: granthalay
+    spec:
+      containers:
+        - name: postgres
+          image: docker.io/library/postgres:18-alpine
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: granthalay-secret
+                  key: POSTGRES_DB
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: granthalay-secret
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: granthalay-secret
+                  key: POSTGRES_PASSWORD
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - granthalay
+                - -d
+                - granthalay
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - granthalay
+                - -d
+                - granthalay
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 10Gi


### PR DESCRIPTION
## Summary

This PR implements issue #18 (*Deploy the API safely to OCI Compute*), adding complete deployment, network isolation, secret management, container resources, and operational runbooks for **OCI Kubernetes (OKE)** clusters and **OCI Compute** VMs.

## Acceptance Criteria & Solution Summary

- **OCI Architecture & Non-Root Containers**: Configured non-root execution ( in Dockerfile,  in K8s). Multi-arch build (, ) via GHCR container workflow.
- **OCI Kubernetes (OKE) Manifests ()**:
  - : Rolling updates, readiness/liveness HTTP probes (, ), non-root security context, and JVM memory flags ().
  - : PostgreSQL 18  with  (OCI  storage) and private .
  - : Ingress routing for HTTPS TLS termination.
  - : Rotatable environment variables and secrets outside of source control.
- **Docker Compose Stack ( & )**:
  - Full service stack (, , ) with internal networking, persistent volumes, health checks, and RAM limits suitable for OCI Free Tier instances.
- **Network Isolation**: Only HTTPS (/) is exposed publicly. PostgreSQL () and API () are unexposed to the host/internet, running on private networks.
- **CI/CD & Operational Runbook**:
  - : Protected deployment workflow for  and  targets.
  - : Operational runbook detailing OKE deployment (), Compose deployment, secret rotation, memory limits, and rollback commands ().
  - : Updated architecture documentation.