### PR TITLE
Catalog: model titles, editions, contributors, pricing, and availability

### DIFF
--- a/src/main/java/dev/samster/granthalay/catalog/CatalogContributorResponse.java
+++ b/src/main/java/dev/samster/granthalay/catalog/CatalogContributorResponse.java
@@ -1,0 +1,4 @@
+package dev.samster.granthalay.catalog;
+
+public record CatalogContributorResponse(String id, String name, String role, String bio) {
+}

--- a/src/main/java/dev/samster/granthalay/catalog/CatalogController.java
+++ b/src/main/java/dev/samster/granthalay/catalog/CatalogController.java
@@ -1,0 +1,72 @@
+package dev.samster.granthalay.catalog;
+
+import java.net.URI;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/catalog")
+public class CatalogController {
+
+	private final CatalogQueryUseCase catalogQueryUseCase;
+
+	public CatalogController(CatalogQueryUseCase catalogQueryUseCase) {
+		this.catalogQueryUseCase = catalogQueryUseCase;
+	}
+
+	@GetMapping("/titles")
+	public ResponseEntity<CatalogPageResponse<CatalogTitleSummaryResponse>> listTitles(
+			@RequestParam(required = false) String search, @RequestParam(required = false) String language,
+			@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "20") int size) {
+		CatalogPageResponse<CatalogTitleSummaryResponse> response = catalogQueryUseCase.listTitles(search, language,
+				page, size);
+		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping("/titles/{slug}")
+	public ResponseEntity<CatalogTitleDetailResponse> getTitleBySlug(@PathVariable String slug) {
+		CatalogTitleDetailResponse response = catalogQueryUseCase.getTitleBySlug(slug)
+			.orElseThrow(() -> new CatalogNotFoundException("Title not found for slug: " + slug));
+		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping("/editions/{editionId}")
+	public ResponseEntity<CatalogEditionResponse> getEditionById(@PathVariable String editionId) {
+		CatalogEditionResponse response = catalogQueryUseCase.getEditionById(editionId)
+			.orElseThrow(() -> new CatalogNotFoundException("Edition not found for id: " + editionId));
+		return ResponseEntity.ok(response);
+	}
+
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<ProblemDetail> handleIllegalArgumentException(IllegalArgumentException ex) {
+		var problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage());
+		problem.setType(URI.create("about:blank"));
+		problem.setTitle("Bad Request");
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problem);
+	}
+
+	@ExceptionHandler(CatalogNotFoundException.class)
+	public ResponseEntity<ProblemDetail> handleNotFoundException(CatalogNotFoundException ex) {
+		var problem = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, ex.getMessage());
+		problem.setType(URI.create("about:blank"));
+		problem.setTitle("Not Found");
+		return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problem);
+	}
+
+	private static class CatalogNotFoundException extends RuntimeException {
+
+		CatalogNotFoundException(String message) {
+			super(message);
+		}
+
+	}
+
+}

--- a/src/main/java/dev/samster/granthalay/catalog/CatalogEditionResponse.java
+++ b/src/main/java/dev/samster/granthalay/catalog/CatalogEditionResponse.java
@@ -1,0 +1,9 @@
+package dev.samster.granthalay.catalog;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record CatalogEditionResponse(String id, String isbn, String format, int editionNumber, String publisherId,
+		LocalDate publishedDate, String status, List<EditionPriceResponse> prices,
+		List<EditionAvailabilityResponse> availability) {
+}

--- a/src/main/java/dev/samster/granthalay/catalog/CatalogPageResponse.java
+++ b/src/main/java/dev/samster/granthalay/catalog/CatalogPageResponse.java
@@ -1,0 +1,6 @@
+package dev.samster.granthalay.catalog;
+
+import java.util.List;
+
+public record CatalogPageResponse<T>(List<T> content, int page, int size, long totalElements, int totalPages) {
+}

--- a/src/main/java/dev/samster/granthalay/catalog/CatalogQueryUseCase.java
+++ b/src/main/java/dev/samster/granthalay/catalog/CatalogQueryUseCase.java
@@ -1,0 +1,90 @@
+package dev.samster.granthalay.catalog;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class CatalogQueryUseCase {
+
+	private final TitleRepository titleRepository;
+
+	private final EditionRepository editionRepository;
+
+	CatalogQueryUseCase(TitleRepository titleRepository, EditionRepository editionRepository) {
+		this.titleRepository = titleRepository;
+		this.editionRepository = editionRepository;
+	}
+
+	public CatalogPageResponse<CatalogTitleSummaryResponse> listTitles(String search, String language, int page,
+			int size) {
+		int boundedSize = Math.max(1, Math.min(size, 100));
+		int boundedPage = Math.max(0, page);
+		var pageable = PageRequest.of(boundedPage, boundedSize, Sort.by("title").ascending());
+		var pageResult = titleRepository.findCatalogTitles(search, language, pageable);
+
+		var summaries = pageResult.getContent().stream().map(this::toSummaryResponse).toList();
+
+		return new CatalogPageResponse<>(summaries, pageResult.getNumber(), pageResult.getSize(),
+				pageResult.getTotalElements(), pageResult.getTotalPages());
+	}
+
+	public Optional<CatalogTitleDetailResponse> getTitleBySlug(String slug) {
+		return titleRepository.findBySlug(slug).map(this::toDetailResponse);
+	}
+
+	public Optional<CatalogEditionResponse> getEditionById(String editionId) {
+		return editionRepository.findById(editionId).map(this::toEditionResponse);
+	}
+
+	private CatalogTitleSummaryResponse toSummaryResponse(TitleEntity title) {
+		String primaryAuthor = title.getTitleContributors()
+			.stream()
+			.filter(tc -> tc.getId().getRole() == ContributorRole.AUTHOR)
+			.sorted(Comparator.comparingInt(TitleContributorEntity::getDisplayOrder))
+			.map(tc -> tc.getContributor().getName())
+			.findFirst()
+			.orElse(null);
+
+		return new CatalogTitleSummaryResponse(title.getId(), title.getSlug(), title.getTitle(), title.getSubtitle(),
+				title.getLanguage(), primaryAuthor);
+	}
+
+	private CatalogTitleDetailResponse toDetailResponse(TitleEntity title) {
+		var contributors = title.getTitleContributors()
+			.stream()
+			.sorted(Comparator.comparingInt(TitleContributorEntity::getDisplayOrder))
+			.map(tc -> new CatalogContributorResponse(tc.getContributor().getId(), tc.getContributor().getName(),
+					tc.getId().getRole().name(), tc.getContributor().getBio()))
+			.toList();
+
+		var editions = title.getEditions().stream().map(this::toEditionResponse).toList();
+
+		return new CatalogTitleDetailResponse(title.getId(), title.getSlug(), title.getTitle(), title.getSubtitle(),
+				title.getDescription(), title.getLanguage(), contributors, editions);
+	}
+
+	private CatalogEditionResponse toEditionResponse(EditionEntity edition) {
+		var prices = edition.getPrices()
+			.stream()
+			.map(p -> new EditionPriceResponse(p.getCurrency(), p.getAmountInCents(), p.getTerritory()))
+			.toList();
+
+		var availability = edition.getAvailability()
+			.stream()
+			.map(a -> new EditionAvailabilityResponse(a.getTerritory(), a.isAvailable(), a.getAvailableFrom(),
+					a.getAvailableUntil()))
+			.toList();
+
+		return new CatalogEditionResponse(edition.getId(), edition.getIsbn(), edition.getFormat().name(),
+				edition.getEditionNumber(), edition.getPublisherId(), edition.getPublishedDate(),
+				edition.getStatus().name(), prices, availability);
+	}
+
+}

--- a/src/main/java/dev/samster/granthalay/catalog/CatalogTitleDetailResponse.java
+++ b/src/main/java/dev/samster/granthalay/catalog/CatalogTitleDetailResponse.java
@@ -1,0 +1,7 @@
+package dev.samster.granthalay.catalog;
+
+import java.util.List;
+
+public record CatalogTitleDetailResponse(String id, String slug, String title, String subtitle, String description,
+		String language, List<CatalogContributorResponse> contributors, List<CatalogEditionResponse> editions) {
+}

--- a/src/main/java/dev/samster/granthalay/catalog/CatalogTitleSummaryResponse.java
+++ b/src/main/java/dev/samster/granthalay/catalog/CatalogTitleSummaryResponse.java
@@ -1,0 +1,5 @@
+package dev.samster.granthalay.catalog;
+
+public record CatalogTitleSummaryResponse(String id, String slug, String title, String subtitle, String language,
+		String primaryAuthorName) {
+}

--- a/src/main/java/dev/samster/granthalay/catalog/ContributorEntity.java
+++ b/src/main/java/dev/samster/granthalay/catalog/ContributorEntity.java
@@ -1,0 +1,45 @@
+package dev.samster.granthalay.catalog;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "catalog_contributors")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+class ContributorEntity {
+
+	@Id
+	@Column(name = "id", nullable = false, length = 36)
+	private String id;
+
+	@Column(name = "name", nullable = false)
+	private String name;
+
+	@Column(name = "bio", columnDefinition = "TEXT")
+	private String bio;
+
+	@Column(name = "created_at", nullable = false)
+	private Instant createdAt;
+
+	@Column(name = "updated_at", nullable = false)
+	private Instant updatedAt;
+
+	ContributorEntity(String id, String name, String bio, Instant createdAt, Instant updatedAt) {
+		this.id = id;
+		this.name = name;
+		this.bio = bio;
+		this.createdAt = createdAt;
+		this.updatedAt = updatedAt;
+	}
+
+}

--- a/src/main/java/dev/samster/granthalay/catalog/ContributorRepository.java
+++ b/src/main/java/dev/samster/granthalay/catalog/ContributorRepository.java
@@ -1,0 +1,7 @@
+package dev.samster.granthalay.catalog;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface ContributorRepository extends JpaRepository<ContributorEntity, String> {
+
+}

--- a/src/main/java/dev/samster/granthalay/catalog/ContributorRole.java
+++ b/src/main/java/dev/samster/granthalay/catalog/ContributorRole.java
@@ -1,0 +1,7 @@
+package dev.samster.granthalay.catalog;
+
+public enum ContributorRole {
+
+	AUTHOR, TRANSLATOR, ILLUSTRATOR, EDITOR
+
+}

--- a/src/main/java/dev/samster/granthalay/catalog/EditionAvailabilityEntity.java
+++ b/src/main/java/dev/samster/granthalay/catalog/EditionAvailabilityEntity.java
@@ -1,0 +1,62 @@
+package dev.samster.granthalay.catalog;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "catalog_edition_availability")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+class EditionAvailabilityEntity {
+
+	@Id
+	@Column(name = "id", nullable = false, length = 36)
+	private String id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "edition_id", nullable = false)
+	private EditionEntity edition;
+
+	@Column(name = "territory", nullable = false, length = 10)
+	private String territory;
+
+	@Column(name = "available_from")
+	private Instant availableFrom;
+
+	@Column(name = "available_until")
+	private Instant availableUntil;
+
+	@Column(name = "is_available", nullable = false)
+	private boolean isAvailable;
+
+	@Column(name = "created_at", nullable = false)
+	private Instant createdAt;
+
+	@Column(name = "updated_at", nullable = false)
+	private Instant updatedAt;
+
+	EditionAvailabilityEntity(String id, EditionEntity edition, String territory, Instant availableFrom,
+			Instant availableUntil, boolean isAvailable, Instant createdAt, Instant updatedAt) {
+		this.id = id;
+		this.edition = edition;
+		this.territory = territory;
+		this.availableFrom = availableFrom;
+		this.availableUntil = availableUntil;
+		this.isAvailable = isAvailable;
+		this.createdAt = createdAt;
+		this.updatedAt = updatedAt;
+	}
+
+}

--- a/src/main/java/dev/samster/granthalay/catalog/EditionAvailabilityResponse.java
+++ b/src/main/java/dev/samster/granthalay/catalog/EditionAvailabilityResponse.java
@@ -1,0 +1,7 @@
+package dev.samster.granthalay.catalog;
+
+import java.time.Instant;
+
+public record EditionAvailabilityResponse(String territory, boolean isAvailable, Instant availableFrom,
+		Instant availableUntil) {
+}

--- a/src/main/java/dev/samster/granthalay/catalog/EditionEntity.java
+++ b/src/main/java/dev/samster/granthalay/catalog/EditionEntity.java
@@ -1,0 +1,85 @@
+package dev.samster.granthalay.catalog;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "catalog_editions")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+class EditionEntity {
+
+	@Id
+	@Column(name = "id", nullable = false, length = 36)
+	private String id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "title_id", nullable = false)
+	private TitleEntity title;
+
+	@Column(name = "isbn", unique = true, length = 20)
+	private String isbn;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "format", nullable = false, length = 50)
+	private EditionFormat format;
+
+	@Column(name = "edition_number", nullable = false)
+	private int editionNumber;
+
+	@Column(name = "publisher_id", length = 36)
+	private String publisherId;
+
+	@Column(name = "published_date")
+	private LocalDate publishedDate;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status", nullable = false, length = 50)
+	private EditionStatus status;
+
+	@Column(name = "created_at", nullable = false)
+	private Instant createdAt;
+
+	@Column(name = "updated_at", nullable = false)
+	private Instant updatedAt;
+
+	@OneToMany(mappedBy = "edition", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<EditionPriceEntity> prices = new ArrayList<>();
+
+	@OneToMany(mappedBy = "edition", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<EditionAvailabilityEntity> availability = new ArrayList<>();
+
+	EditionEntity(String id, TitleEntity title, String isbn, EditionFormat format, int editionNumber,
+			String publisherId, LocalDate publishedDate, EditionStatus status, Instant createdAt, Instant updatedAt) {
+		this.id = id;
+		this.title = title;
+		this.isbn = isbn;
+		this.format = format;
+		this.editionNumber = editionNumber;
+		this.publisherId = publisherId;
+		this.publishedDate = publishedDate;
+		this.status = status;
+		this.createdAt = createdAt;
+		this.updatedAt = updatedAt;
+	}
+
+}

--- a/src/main/java/dev/samster/granthalay/catalog/EditionFormat.java
+++ b/src/main/java/dev/samster/granthalay/catalog/EditionFormat.java
@@ -1,0 +1,7 @@
+package dev.samster.granthalay.catalog;
+
+public enum EditionFormat {
+
+	EPUB
+
+}

--- a/src/main/java/dev/samster/granthalay/catalog/EditionPriceEntity.java
+++ b/src/main/java/dev/samster/granthalay/catalog/EditionPriceEntity.java
@@ -1,0 +1,58 @@
+package dev.samster.granthalay.catalog;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "catalog_edition_prices")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+class EditionPriceEntity {
+
+	@Id
+	@Column(name = "id", nullable = false, length = 36)
+	private String id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "edition_id", nullable = false)
+	private EditionEntity edition;
+
+	@Column(name = "currency", nullable = false, length = 3)
+	private String currency;
+
+	@Column(name = "amount_in_cents", nullable = false)
+	private long amountInCents;
+
+	@Column(name = "territory", nullable = false, length = 10)
+	private String territory;
+
+	@Column(name = "created_at", nullable = false)
+	private Instant createdAt;
+
+	@Column(name = "updated_at", nullable = false)
+	private Instant updatedAt;
+
+	EditionPriceEntity(String id, EditionEntity edition, String currency, long amountInCents, String territory,
+			Instant createdAt, Instant updatedAt) {
+		this.id = id;
+		this.edition = edition;
+		this.currency = currency;
+		this.amountInCents = amountInCents;
+		this.territory = territory;
+		this.createdAt = createdAt;
+		this.updatedAt = updatedAt;
+	}
+
+}

--- a/src/main/java/dev/samster/granthalay/catalog/EditionPriceResponse.java
+++ b/src/main/java/dev/samster/granthalay/catalog/EditionPriceResponse.java
@@ -1,0 +1,4 @@
+package dev.samster.granthalay.catalog;
+
+public record EditionPriceResponse(String currency, long amountInCents, String territory) {
+}

--- a/src/main/java/dev/samster/granthalay/catalog/EditionRepository.java
+++ b/src/main/java/dev/samster/granthalay/catalog/EditionRepository.java
@@ -1,0 +1,13 @@
+package dev.samster.granthalay.catalog;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface EditionRepository extends JpaRepository<EditionEntity, String> {
+
+	Optional<EditionEntity> findByIsbn(String isbn);
+
+	boolean existsByIsbn(String isbn);
+
+}

--- a/src/main/java/dev/samster/granthalay/catalog/EditionStatus.java
+++ b/src/main/java/dev/samster/granthalay/catalog/EditionStatus.java
@@ -1,0 +1,7 @@
+package dev.samster.granthalay.catalog;
+
+public enum EditionStatus {
+
+	DRAFT, PUBLISHED, ARCHIVED
+
+}

--- a/src/main/java/dev/samster/granthalay/catalog/ManageCatalogUseCase.java
+++ b/src/main/java/dev/samster/granthalay/catalog/ManageCatalogUseCase.java
@@ -1,0 +1,94 @@
+package dev.samster.granthalay.catalog;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class ManageCatalogUseCase {
+
+	private final TitleRepository titleRepository;
+
+	private final ContributorRepository contributorRepository;
+
+	private final EditionRepository editionRepository;
+
+	ManageCatalogUseCase(TitleRepository titleRepository, ContributorRepository contributorRepository,
+			EditionRepository editionRepository) {
+		this.titleRepository = titleRepository;
+		this.contributorRepository = contributorRepository;
+		this.editionRepository = editionRepository;
+	}
+
+	public ContributorEntity createContributor(String name, String bio) {
+		Instant now = Instant.now();
+		ContributorEntity contributor = new ContributorEntity(UUID.randomUUID().toString(), name, bio, now, now);
+		return contributorRepository.save(contributor);
+	}
+
+	public TitleEntity createTitle(String slug, String title, String subtitle, String description, String language) {
+		if (titleRepository.existsBySlug(slug)) {
+			throw new IllegalArgumentException("Title with slug '" + slug + "' already exists");
+		}
+		Instant now = Instant.now();
+		TitleEntity titleEntity = new TitleEntity(UUID.randomUUID().toString(), slug, title, subtitle, description,
+				language, now, now);
+		return titleRepository.save(titleEntity);
+	}
+
+	public void addContributorToTitle(String titleId, String contributorId, ContributorRole role, int displayOrder) {
+		TitleEntity title = titleRepository.findById(titleId)
+			.orElseThrow(() -> new IllegalArgumentException("Title not found: " + titleId));
+		ContributorEntity contributor = contributorRepository.findById(contributorId)
+			.orElseThrow(() -> new IllegalArgumentException("Contributor not found: " + contributorId));
+
+		TitleContributorEntity tc = new TitleContributorEntity(title, contributor, role, displayOrder);
+		title.getTitleContributors().add(tc);
+		titleRepository.save(title);
+	}
+
+	public EditionEntity addEdition(String titleId, String isbn, EditionFormat format, int editionNumber,
+			String publisherId, LocalDate publishedDate, EditionStatus status) {
+		TitleEntity title = titleRepository.findById(titleId)
+			.orElseThrow(() -> new IllegalArgumentException("Title not found: " + titleId));
+
+		if (isbn != null && editionRepository.existsByIsbn(isbn)) {
+			throw new IllegalArgumentException("Edition with ISBN '" + isbn + "' already exists");
+		}
+
+		Instant now = Instant.now();
+		EditionEntity edition = new EditionEntity(UUID.randomUUID().toString(), title, isbn, format, editionNumber,
+				publisherId, publishedDate, status, now, now);
+		title.getEditions().add(edition);
+		titleRepository.save(title);
+		return edition;
+	}
+
+	public void setPrice(String editionId, String currency, long amountInCents, String territory) {
+		EditionEntity edition = editionRepository.findById(editionId)
+			.orElseThrow(() -> new IllegalArgumentException("Edition not found: " + editionId));
+
+		Instant now = Instant.now();
+		EditionPriceEntity price = new EditionPriceEntity(UUID.randomUUID().toString(), edition, currency,
+				amountInCents, territory, now, now);
+		edition.getPrices().add(price);
+		editionRepository.save(edition);
+	}
+
+	public void setAvailability(String editionId, String territory, Instant availableFrom, Instant availableUntil,
+			boolean isAvailable) {
+		EditionEntity edition = editionRepository.findById(editionId)
+			.orElseThrow(() -> new IllegalArgumentException("Edition not found: " + editionId));
+
+		Instant now = Instant.now();
+		EditionAvailabilityEntity availability = new EditionAvailabilityEntity(UUID.randomUUID().toString(), edition,
+				territory, availableFrom, availableUntil, isAvailable, now, now);
+		edition.getAvailability().add(availability);
+		editionRepository.save(edition);
+	}
+
+}

--- a/src/main/java/dev/samster/granthalay/catalog/TitleContributorEntity.java
+++ b/src/main/java/dev/samster/granthalay/catalog/TitleContributorEntity.java
@@ -1,0 +1,46 @@
+package dev.samster.granthalay.catalog;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "catalog_title_contributors")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+class TitleContributorEntity {
+
+	@EmbeddedId
+	private TitleContributorId id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@MapsId("titleId")
+	@JoinColumn(name = "title_id")
+	private TitleEntity title;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@MapsId("contributorId")
+	@JoinColumn(name = "contributor_id")
+	private ContributorEntity contributor;
+
+	@Column(name = "display_order", nullable = false)
+	private int displayOrder;
+
+	TitleContributorEntity(TitleEntity title, ContributorEntity contributor, ContributorRole role, int displayOrder) {
+		this.id = new TitleContributorId(title.getId(), contributor.getId(), role);
+		this.title = title;
+		this.contributor = contributor;
+		this.displayOrder = displayOrder;
+	}
+
+}

--- a/src/main/java/dev/samster/granthalay/catalog/TitleContributorId.java
+++ b/src/main/java/dev/samster/granthalay/catalog/TitleContributorId.java
@@ -1,0 +1,48 @@
+package dev.samster.granthalay.catalog;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+class TitleContributorId implements Serializable {
+
+	@Column(name = "title_id", nullable = false, length = 36)
+	private String titleId;
+
+	@Column(name = "contributor_id", nullable = false, length = 36)
+	private String contributorId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "role", nullable = false, length = 50)
+	private ContributorRole role;
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		TitleContributorId that = (TitleContributorId) o;
+		return Objects.equals(titleId, that.titleId) && Objects.equals(contributorId, that.contributorId)
+				&& role == that.role;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(titleId, contributorId, role);
+	}
+
+}

--- a/src/main/java/dev/samster/granthalay/catalog/TitleEntity.java
+++ b/src/main/java/dev/samster/granthalay/catalog/TitleEntity.java
@@ -1,0 +1,70 @@
+package dev.samster.granthalay.catalog;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "catalog_titles")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+class TitleEntity {
+
+	@Id
+	@Column(name = "id", nullable = false, length = 36)
+	private String id;
+
+	@Column(name = "slug", nullable = false, unique = true)
+	private String slug;
+
+	@Column(name = "title", nullable = false)
+	private String title;
+
+	@Column(name = "subtitle")
+	private String subtitle;
+
+	@Column(name = "description", columnDefinition = "TEXT")
+	private String description;
+
+	@Column(name = "language", nullable = false, length = 10)
+	private String language;
+
+	@Column(name = "created_at", nullable = false)
+	private Instant createdAt;
+
+	@Column(name = "updated_at", nullable = false)
+	private Instant updatedAt;
+
+	@OneToMany(mappedBy = "title", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OrderBy("displayOrder ASC")
+	private List<TitleContributorEntity> titleContributors = new ArrayList<>();
+
+	@OneToMany(mappedBy = "title", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<EditionEntity> editions = new ArrayList<>();
+
+	TitleEntity(String id, String slug, String title, String subtitle, String description, String language,
+			Instant createdAt, Instant updatedAt) {
+		this.id = id;
+		this.slug = slug;
+		this.title = title;
+		this.subtitle = subtitle;
+		this.description = description;
+		this.language = language;
+		this.createdAt = createdAt;
+		this.updatedAt = updatedAt;
+	}
+
+}

--- a/src/main/java/dev/samster/granthalay/catalog/TitleRepository.java
+++ b/src/main/java/dev/samster/granthalay/catalog/TitleRepository.java
@@ -1,0 +1,29 @@
+package dev.samster.granthalay.catalog;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+interface TitleRepository extends JpaRepository<TitleEntity, String> {
+
+	Optional<TitleEntity> findBySlug(String slug);
+
+	boolean existsBySlug(String slug);
+
+	@Query("""
+			SELECT DISTINCT t FROM TitleEntity t
+			LEFT JOIN t.titleContributors tc
+			LEFT JOIN tc.contributor c
+			WHERE (:search IS NULL OR :search = '' OR
+				LOWER(t.title) LIKE LOWER(CONCAT('%', :search, '%')) OR
+				LOWER(c.name) LIKE LOWER(CONCAT('%', :search, '%')))
+			AND (:language IS NULL OR :language = '' OR t.language = :language)
+			""")
+	Page<TitleEntity> findCatalogTitles(@Param("search") String search, @Param("language") String language,
+			Pageable pageable);
+
+}

--- a/src/main/java/dev/samster/granthalay/operations/SecurityConfiguration.java
+++ b/src/main/java/dev/samster/granthalay/operations/SecurityConfiguration.java
@@ -40,7 +40,8 @@ class SecurityConfiguration {
 			.cors(Customizer.withDefaults())
 			.authorizeHttpRequests(requests -> requests
 				.requestMatchers(HttpMethod.GET, "/actuator/health", "/actuator/health/liveness",
-						"/actuator/health/readiness", "/api/v1", "/openapi/granthalay-api-v1.yaml")
+						"/actuator/health/readiness", "/api/v1", "/openapi/granthalay-api-v1.yaml",
+						"/api/v1/catalog/**")
 				.permitAll()
 				.requestMatchers(HttpMethod.POST, "/api/v1/auth/register", "/api/v1/auth/verify-email",
 						"/api/v1/auth/sign-in", "/api/v1/auth/sign-out", "/api/v1/auth/request-password-reset",

--- a/src/main/resources/db/migration/V5__catalog_schema.sql
+++ b/src/main/resources/db/migration/V5__catalog_schema.sql
@@ -1,0 +1,86 @@
+CREATE TABLE catalog_titles (
+	id VARCHAR(36) NOT NULL,
+	slug VARCHAR(255) NOT NULL UNIQUE,
+	title VARCHAR(255) NOT NULL,
+	subtitle VARCHAR(255),
+	description TEXT,
+	language VARCHAR(10) NOT NULL,
+	created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+	updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+	CONSTRAINT pk_catalog_titles PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_catalog_titles_slug ON catalog_titles (slug);
+CREATE INDEX idx_catalog_titles_language ON catalog_titles (language);
+
+CREATE TABLE catalog_contributors (
+	id VARCHAR(36) NOT NULL,
+	name VARCHAR(255) NOT NULL,
+	bio TEXT,
+	created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+	updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+	CONSTRAINT pk_catalog_contributors PRIMARY KEY (id)
+);
+
+CREATE TABLE catalog_title_contributors (
+	title_id VARCHAR(36) NOT NULL,
+	contributor_id VARCHAR(36) NOT NULL,
+	role VARCHAR(50) NOT NULL,
+	display_order INT NOT NULL DEFAULT 0,
+	CONSTRAINT pk_catalog_title_contributors PRIMARY KEY (title_id, contributor_id, role),
+	CONSTRAINT fk_catalog_title_contributors_title FOREIGN KEY (title_id) REFERENCES catalog_titles (id) ON DELETE CASCADE,
+	CONSTRAINT fk_catalog_title_contributors_contributor FOREIGN KEY (contributor_id) REFERENCES catalog_contributors (id) ON DELETE RESTRICT
+);
+
+CREATE INDEX idx_catalog_title_contributors_title ON catalog_title_contributors (title_id);
+CREATE INDEX idx_catalog_title_contributors_contributor ON catalog_title_contributors (contributor_id);
+
+CREATE TABLE catalog_editions (
+	id VARCHAR(36) NOT NULL,
+	title_id VARCHAR(36) NOT NULL,
+	isbn VARCHAR(20) UNIQUE,
+	format VARCHAR(50) NOT NULL,
+	edition_number INT NOT NULL DEFAULT 1,
+	publisher_id VARCHAR(36),
+	published_date DATE,
+	status VARCHAR(50) NOT NULL,
+	created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+	updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+	CONSTRAINT pk_catalog_editions PRIMARY KEY (id),
+	CONSTRAINT fk_catalog_editions_title FOREIGN KEY (title_id) REFERENCES catalog_titles (id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_catalog_editions_title ON catalog_editions (title_id);
+CREATE INDEX idx_catalog_editions_isbn ON catalog_editions (isbn);
+CREATE INDEX idx_catalog_editions_status ON catalog_editions (status);
+
+CREATE TABLE catalog_edition_prices (
+	id VARCHAR(36) NOT NULL,
+	edition_id VARCHAR(36) NOT NULL,
+	currency VARCHAR(3) NOT NULL,
+	amount_in_cents BIGINT NOT NULL,
+	territory VARCHAR(10) NOT NULL,
+	created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+	updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+	CONSTRAINT pk_catalog_edition_prices PRIMARY KEY (id),
+	CONSTRAINT fk_catalog_edition_prices_edition FOREIGN KEY (edition_id) REFERENCES catalog_editions (id) ON DELETE CASCADE,
+	CONSTRAINT uq_catalog_edition_prices UNIQUE (edition_id, currency, territory)
+);
+
+CREATE INDEX idx_catalog_edition_prices_edition ON catalog_edition_prices (edition_id);
+
+CREATE TABLE catalog_edition_availability (
+	id VARCHAR(36) NOT NULL,
+	edition_id VARCHAR(36) NOT NULL,
+	territory VARCHAR(10) NOT NULL,
+	available_from TIMESTAMP WITH TIME ZONE,
+	available_until TIMESTAMP WITH TIME ZONE,
+	is_available BOOLEAN NOT NULL DEFAULT TRUE,
+	created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+	updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+	CONSTRAINT pk_catalog_edition_availability PRIMARY KEY (id),
+	CONSTRAINT fk_catalog_edition_availability_edition FOREIGN KEY (edition_id) REFERENCES catalog_editions (id) ON DELETE CASCADE,
+	CONSTRAINT uq_catalog_edition_availability UNIQUE (edition_id, territory)
+);
+
+CREATE INDEX idx_catalog_edition_availability_edition ON catalog_edition_availability (edition_id);

--- a/src/main/resources/static/openapi/granthalay-api-v1.yaml
+++ b/src/main/resources/static/openapi/granthalay-api-v1.yaml
@@ -14,6 +14,8 @@ tags:
     description: API discovery and contract metadata.
   - name: Identity
     description: User account registration, email verification, and session sign-in.
+  - name: Catalog
+    description: Book catalog metadata, titles, editions, and availability.
 paths:
   /api/v1:
     get:
@@ -188,6 +190,84 @@ paths:
               schema:
                 $ref: '#/components/schemas/AccountResponse'
         '401':
+          $ref: '#/components/responses/Problem'
+        '500':
+          $ref: '#/components/responses/Problem'
+  /api/v1/catalog/titles:
+    get:
+      tags: [Catalog]
+      operationId: listCatalogTitles
+      summary: Browse and search catalog titles
+      security: []
+      parameters:
+        - name: search
+          in: query
+          description: Search text matching title or author name.
+          required: false
+          schema:
+            type: string
+        - name: language
+          in: query
+          description: Filter titles by ISO language code.
+          required: false
+          schema:
+            type: string
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/Size'
+      responses:
+        '200':
+          description: Paginated catalog titles list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CatalogTitleSummaryPage'
+        '500':
+          $ref: '#/components/responses/Problem'
+  /api/v1/catalog/titles/{slug}:
+    get:
+      tags: [Catalog]
+      operationId: getCatalogTitleBySlug
+      summary: Fetch catalog title details by slug
+      security: []
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          description: Unique URL slug for the catalog title.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Catalog title details with contributors and available editions.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CatalogTitleDetailResponse'
+        '404':
+          $ref: '#/components/responses/Problem'
+        '500':
+          $ref: '#/components/responses/Problem'
+  /api/v1/catalog/editions/{editionId}:
+    get:
+      tags: [Catalog]
+      operationId: getCatalogEditionById
+      summary: Fetch catalog edition details by edition ID
+      security: []
+      parameters:
+        - name: editionId
+          in: path
+          required: true
+          description: Unique identifier for the catalog edition.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Catalog edition details with pricing and availability.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CatalogEditionResponse'
+        '404':
           $ref: '#/components/responses/Problem'
         '500':
           $ref: '#/components/responses/Problem'
@@ -403,3 +483,136 @@ components:
         message:
           type: string
           description: Safe human-readable explanation; rejected values are omitted.
+    CatalogTitleSummaryResponse:
+      type: object
+      additionalProperties: false
+      required: [id, slug, title, language]
+      properties:
+        id:
+          type: string
+        slug:
+          type: string
+        title:
+          type: string
+        subtitle:
+          type: string
+        language:
+          type: string
+        primaryAuthorName:
+          type: string
+    CatalogContributorResponse:
+      type: object
+      additionalProperties: false
+      required: [id, name, role]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        role:
+          type: string
+        bio:
+          type: string
+    EditionPriceResponse:
+      type: object
+      additionalProperties: false
+      required: [currency, amountInCents, territory]
+      properties:
+        currency:
+          type: string
+        amountInCents:
+          type: integer
+          format: int64
+        territory:
+          type: string
+    EditionAvailabilityResponse:
+      type: object
+      additionalProperties: false
+      required: [territory, isAvailable]
+      properties:
+        territory:
+          type: string
+        isAvailable:
+          type: boolean
+        availableFrom:
+          type: string
+          format: date-time
+        availableUntil:
+          type: string
+          format: date-time
+    CatalogEditionResponse:
+      type: object
+      additionalProperties: false
+      required: [id, format, editionNumber, status, prices, availability]
+      properties:
+        id:
+          type: string
+        isbn:
+          type: string
+        format:
+          type: string
+        editionNumber:
+          type: integer
+          format: int32
+        publisherId:
+          type: string
+        publishedDate:
+          type: string
+          format: date
+        status:
+          type: string
+        prices:
+          type: array
+          items:
+            $ref: '#/components/schemas/EditionPriceResponse'
+        availability:
+          type: array
+          items:
+            $ref: '#/components/schemas/EditionAvailabilityResponse'
+    CatalogTitleDetailResponse:
+      type: object
+      additionalProperties: false
+      required: [id, slug, title, language, contributors, editions]
+      properties:
+        id:
+          type: string
+        slug:
+          type: string
+        title:
+          type: string
+        subtitle:
+          type: string
+        description:
+          type: string
+        language:
+          type: string
+        contributors:
+          type: array
+          items:
+            $ref: '#/components/schemas/CatalogContributorResponse'
+        editions:
+          type: array
+          items:
+            $ref: '#/components/schemas/CatalogEditionResponse'
+    CatalogTitleSummaryPage:
+      type: object
+      additionalProperties: false
+      required: [content, page, size, totalElements, totalPages]
+      properties:
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/CatalogTitleSummaryResponse'
+        page:
+          type: integer
+          format: int32
+        size:
+          type: integer
+          format: int32
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+          format: int32
+

--- a/src/test/java/dev/samster/granthalay/DatabaseIT.java
+++ b/src/test/java/dev/samster/granthalay/DatabaseIT.java
@@ -36,7 +36,7 @@ class DatabaseIT {
 	@Test
 	void migrationsAreAppliedAndDoNotRepeat() {
 		flyway.validate();
-		assertThat(flyway.info().applied()).hasSize(4);
+		assertThat(flyway.info().applied()).hasSize(5);
 
 		assertThat(flyway.info().pending()).isEmpty();
 		assertThat(flyway.migrate().migrationsExecuted).isZero();

--- a/src/test/java/dev/samster/granthalay/catalog/CatalogIT.java
+++ b/src/test/java/dev/samster/granthalay/catalog/CatalogIT.java
@@ -1,0 +1,133 @@
+package dev.samster.granthalay.catalog;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Instant;
+import java.time.LocalDate;
+
+import dev.samster.granthalay.TestcontainersConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class CatalogIT {
+
+	@LocalServerPort
+	int port;
+
+	@Autowired
+	ManageCatalogUseCase manageCatalogUseCase;
+
+	@Autowired
+	TitleRepository titleRepository;
+
+	@Autowired
+	ContributorRepository contributorRepository;
+
+	@Autowired
+	EditionRepository editionRepository;
+
+	private HttpClient client;
+
+	private String titleSlug;
+
+	private String editionId;
+
+	@BeforeEach
+	void setUp() {
+		editionRepository.deleteAll();
+		titleRepository.deleteAll();
+		contributorRepository.deleteAll();
+
+		client = HttpClient.newHttpClient();
+		titleSlug = "the-god-of-small-things-" + System.currentTimeMillis();
+
+		var contributor = manageCatalogUseCase.createContributor("Arundhati Roy",
+				"Indian author and political activist.");
+		var title = manageCatalogUseCase.createTitle(titleSlug, "The God of Small Things", "A Novel",
+				"A story about the childhood experiences of fraternal twins...", "en");
+
+		manageCatalogUseCase.addContributorToTitle(title.getId(), contributor.getId(), ContributorRole.AUTHOR, 1);
+
+		var edition = manageCatalogUseCase.addEdition(title.getId(), "9780679457312", EditionFormat.EPUB, 1, null,
+				LocalDate.of(1997, 4, 4), EditionStatus.PUBLISHED);
+		editionId = edition.getId();
+
+		manageCatalogUseCase.setPrice(editionId, "USD", 1499, "GLOBAL");
+		manageCatalogUseCase.setPrice(editionId, "INR", 49900, "IN");
+
+		manageCatalogUseCase.setAvailability(editionId, "GLOBAL", Instant.now().minusSeconds(86400), null, true);
+	}
+
+	@Test
+	void listsCatalogTitlesWithPaginationAndFiltering() throws Exception {
+		var req = HttpRequest
+			.newBuilder(URI
+				.create("http://localhost:" + port + "/api/v1/catalog/titles?search=Small&language=en&page=0&size=10"))
+			.GET()
+			.build();
+		var res = client.send(req, HttpResponse.BodyHandlers.ofString());
+
+		assertThat(res.statusCode()).isEqualTo(200);
+		assertThat(res.headers().firstValue("Content-Type").orElse("")).contains("application/json");
+		assertThat(res.body()).contains(titleSlug);
+		assertThat(res.body()).contains("The God of Small Things");
+		assertThat(res.body()).contains("Arundhati Roy");
+	}
+
+	@Test
+	void fetchesCatalogTitleDetailBySlug() throws Exception {
+		var req = HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/api/v1/catalog/titles/" + titleSlug))
+			.GET()
+			.build();
+		var res = client.send(req, HttpResponse.BodyHandlers.ofString());
+
+		assertThat(res.statusCode()).isEqualTo(200);
+		assertThat(res.headers().firstValue("Content-Type").orElse("")).contains("application/json");
+		assertThat(res.body()).contains(titleSlug);
+		assertThat(res.body()).contains("The God of Small Things");
+		assertThat(res.body()).contains("Arundhati Roy");
+		assertThat(res.body()).contains("AUTHOR");
+		assertThat(res.body()).contains("EPUB");
+		assertThat(res.body()).contains("USD");
+	}
+
+	@Test
+	void fetchesCatalogEditionById() throws Exception {
+		var req = HttpRequest
+			.newBuilder(URI.create("http://localhost:" + port + "/api/v1/catalog/editions/" + editionId))
+			.GET()
+			.build();
+		var res = client.send(req, HttpResponse.BodyHandlers.ofString());
+
+		assertThat(res.statusCode()).isEqualTo(200);
+		assertThat(res.headers().firstValue("Content-Type").orElse("")).contains("application/json");
+		assertThat(res.body()).contains(editionId);
+		assertThat(res.body()).contains("PUBLISHED");
+		assertThat(res.body()).contains("GLOBAL");
+	}
+
+	@Test
+	void returnsProblemDetailsWhenTitleNotFound() throws Exception {
+		var req = HttpRequest
+			.newBuilder(URI.create("http://localhost:" + port + "/api/v1/catalog/titles/non-existent-slug-xyz"))
+			.GET()
+			.build();
+		var res = client.send(req, HttpResponse.BodyHandlers.ofString());
+
+		assertThat(res.statusCode()).isEqualTo(404);
+		assertThat(res.headers().firstValue("Content-Type").orElse("")).contains("application/problem+json");
+		assertThat(res.body()).contains("Not Found");
+		assertThat(res.body()).contains("non-existent-slug-xyz");
+	}
+
+}


### PR DESCRIPTION
## Summary of Changes

Implements catalog domain modeling, Flyway database schema, application use cases, REST endpoints under `/api/v1/catalog`, and OpenAPI contract updates for issue #14.

### 1. Database Schema & Flyway Migration (`V5__catalog_schema.sql`)
- Added PostgreSQL tables: `catalog_titles`, `catalog_contributors`, `catalog_title_contributors`, `catalog_editions`, `catalog_edition_prices`, and `catalog_edition_availability`.
- Foreign key constraints, unique indexes (slug, ISBN, currency/territory pricing, territory availability), and timestamps.

### 2. Catalog Module Implementation (`dev.samster.granthalay.catalog`)
- **JPA Entities**: `TitleEntity`, `ContributorEntity`, `TitleContributorEntity`, `TitleContributorId`, `EditionEntity`, `EditionPriceEntity`, `EditionAvailabilityEntity`.
- **Spring Data Repositories**: `TitleRepository`, `ContributorRepository`, `EditionRepository`.
- **Application Services & DTOs**: `CatalogQueryUseCase`, `ManageCatalogUseCase`, transport records (`CatalogTitleSummaryResponse`, `CatalogTitleDetailResponse`, `CatalogContributorResponse`, `CatalogEditionResponse`, `EditionPriceResponse`, `EditionAvailabilityResponse`, `CatalogPageResponse`).
- **REST Controller**: `CatalogController` exposing public `/api/v1/catalog/titles`, `/api/v1/catalog/titles/{slug}`, `/api/v1/catalog/editions/{editionId}` endpoints with RFC 9457 Problem Details error formatting.

### 3. Security & OpenAPI
- Permitted public `GET /api/v1/catalog/**` requests in `SecurityConfiguration`.
- Added `Catalog` tag, paths, and component schemas to `granthalay-api-v1.yaml`.

### 4. Testing & Verification
- Created `CatalogIT` test suite covering title listing, searching, title details, edition details, and 404 Problem Details.
- Updated `DatabaseIT` to validate 5 applied Flyway migrations.
- Executed `./mvnw verify` with clean success.

Closes #14
