### PR TITLE
Publishing: build publisher release and availability operations

### DIFF
--- a/src/main/java/dev/samster/granthalay/catalog/ManageCatalogUseCase.java
+++ b/src/main/java/dev/samster/granthalay/catalog/ManageCatalogUseCase.java
@@ -24,20 +24,20 @@ public class ManageCatalogUseCase {
 		this.editionRepository = editionRepository;
 	}
 
-	public ContributorEntity createContributor(String name, String bio) {
+	public String createContributor(String name, String bio) {
 		Instant now = Instant.now();
 		ContributorEntity contributor = new ContributorEntity(UUID.randomUUID().toString(), name, bio, now, now);
-		return contributorRepository.save(contributor);
+		return contributorRepository.save(contributor).getId();
 	}
 
-	public TitleEntity createTitle(String slug, String title, String subtitle, String description, String language) {
+	public String createTitle(String slug, String title, String subtitle, String description, String language) {
 		if (titleRepository.existsBySlug(slug)) {
 			throw new IllegalArgumentException("Title with slug '" + slug + "' already exists");
 		}
 		Instant now = Instant.now();
 		TitleEntity titleEntity = new TitleEntity(UUID.randomUUID().toString(), slug, title, subtitle, description,
 				language, now, now);
-		return titleRepository.save(titleEntity);
+		return titleRepository.save(titleEntity).getId();
 	}
 
 	public void addContributorToTitle(String titleId, String contributorId, ContributorRole role, int displayOrder) {
@@ -51,8 +51,8 @@ public class ManageCatalogUseCase {
 		titleRepository.save(title);
 	}
 
-	public EditionEntity addEdition(String titleId, String isbn, EditionFormat format, int editionNumber,
-			String publisherId, LocalDate publishedDate, EditionStatus status) {
+	public String addEdition(String titleId, String isbn, EditionFormat format, int editionNumber, String publisherId,
+			LocalDate publishedDate, EditionStatus status) {
 		TitleEntity title = titleRepository.findById(titleId)
 			.orElseThrow(() -> new IllegalArgumentException("Title not found: " + titleId));
 
@@ -65,7 +65,7 @@ public class ManageCatalogUseCase {
 				publisherId, publishedDate, status, now, now);
 		title.getEditions().add(edition);
 		titleRepository.save(title);
-		return edition;
+		return edition.getId();
 	}
 
 	public void setPrice(String editionId, String currency, long amountInCents, String territory) {
@@ -88,6 +88,14 @@ public class ManageCatalogUseCase {
 		EditionAvailabilityEntity availability = new EditionAvailabilityEntity(UUID.randomUUID().toString(), edition,
 				territory, availableFrom, availableUntil, isAvailable, now, now);
 		edition.getAvailability().add(availability);
+		editionRepository.save(edition);
+	}
+
+	public void updateEditionStatus(String editionId, EditionStatus status) {
+		EditionEntity edition = editionRepository.findById(editionId)
+			.orElseThrow(() -> new IllegalArgumentException("Edition not found: " + editionId));
+		edition.setStatus(status);
+		edition.setUpdatedAt(Instant.now());
 		editionRepository.save(edition);
 	}
 

--- a/src/main/java/dev/samster/granthalay/operations/SecurityConfiguration.java
+++ b/src/main/java/dev/samster/granthalay/operations/SecurityConfiguration.java
@@ -51,6 +51,8 @@ class SecurityConfiguration {
 				.authenticated()
 				.requestMatchers(HttpMethod.POST, "/api/v1/auth/revoke-sessions")
 				.authenticated()
+				.requestMatchers("/api/v1/publishing/**")
+				.authenticated()
 				.anyRequest()
 				.denyAll())
 			.exceptionHandling(

--- a/src/main/java/dev/samster/granthalay/publishing/PublishReleaseRequest.java
+++ b/src/main/java/dev/samster/granthalay/publishing/PublishReleaseRequest.java
@@ -1,0 +1,8 @@
+package dev.samster.granthalay.publishing;
+
+import java.time.Instant;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PublishReleaseRequest(Instant scheduledAt, @NotBlank String performedBy) {
+}

--- a/src/main/java/dev/samster/granthalay/publishing/PublisherEntity.java
+++ b/src/main/java/dev/samster/granthalay/publishing/PublisherEntity.java
@@ -1,0 +1,53 @@
+package dev.samster.granthalay.publishing;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "publishing_publishers")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+class PublisherEntity {
+
+	@Id
+	@Column(name = "id", nullable = false, length = 36)
+	private String id;
+
+	@Column(name = "name", nullable = false)
+	private String name;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status", nullable = false, length = 50)
+	private PublisherStatus status;
+
+	@Column(name = "contact_email", nullable = false)
+	private String contactEmail;
+
+	@Column(name = "created_at", nullable = false)
+	private Instant createdAt;
+
+	@Column(name = "updated_at", nullable = false)
+	private Instant updatedAt;
+
+	PublisherEntity(String id, String name, PublisherStatus status, String contactEmail, Instant createdAt,
+			Instant updatedAt) {
+		this.id = id;
+		this.name = name;
+		this.status = status;
+		this.contactEmail = contactEmail;
+		this.createdAt = createdAt;
+		this.updatedAt = updatedAt;
+	}
+
+}

--- a/src/main/java/dev/samster/granthalay/publishing/PublisherReleaseUseCase.java
+++ b/src/main/java/dev/samster/granthalay/publishing/PublisherReleaseUseCase.java
@@ -1,0 +1,184 @@
+package dev.samster.granthalay.publishing;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import dev.samster.granthalay.catalog.EditionStatus;
+import dev.samster.granthalay.catalog.ManageCatalogUseCase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class PublisherReleaseUseCase {
+
+	private final PublisherRepository publisherRepository;
+
+	private final SubmissionRepository submissionRepository;
+
+	private final PublishingAuditEventRepository auditEventRepository;
+
+	private final ManageCatalogUseCase manageCatalogUseCase;
+
+	PublisherReleaseUseCase(PublisherRepository publisherRepository, SubmissionRepository submissionRepository,
+			PublishingAuditEventRepository auditEventRepository, ManageCatalogUseCase manageCatalogUseCase) {
+		this.publisherRepository = publisherRepository;
+		this.submissionRepository = submissionRepository;
+		this.auditEventRepository = auditEventRepository;
+		this.manageCatalogUseCase = manageCatalogUseCase;
+	}
+
+	public PublisherEntity createPublisher(String name, String contactEmail) {
+		Instant now = Instant.now();
+		PublisherEntity publisher = new PublisherEntity(UUID.randomUUID().toString(), name, PublisherStatus.APPROVED,
+				contactEmail, now, now);
+		return publisherRepository.save(publisher);
+	}
+
+	public SubmissionResponse submitEdition(SubmitEditionRequest request, String performedBy) {
+		PublisherEntity publisher = publisherRepository.findById(request.publisherId())
+			.orElseThrow(() -> new IllegalArgumentException("Publisher not found: " + request.publisherId()));
+
+		Instant now = Instant.now();
+		SubmissionEntity submission = new SubmissionEntity(UUID.randomUUID().toString(), publisher, request.editionId(),
+				request.title(), request.isbn(), SubmissionStatus.SUBMITTED, null, null, now, now);
+		submissionRepository.save(submission);
+
+		recordAudit(submission, publisher.getId(), PublishingAction.SUBMIT, performedBy,
+				"Submitted edition for review");
+
+		return toResponse(submission);
+	}
+
+	public SubmissionResponse reviewSubmission(String submissionId, ReviewSubmissionRequest request) {
+		SubmissionEntity submission = getSubmissionEntity(submissionId);
+
+		if (submission.getStatus() != SubmissionStatus.SUBMITTED
+				&& submission.getStatus() != SubmissionStatus.IN_REVIEW) {
+			throw new IllegalStateException("Cannot review submission in status: " + submission.getStatus());
+		}
+
+		Instant now = Instant.now();
+		if (request.approve()) {
+			submission.setStatus(SubmissionStatus.APPROVED);
+			submission.setRejectionReason(null);
+			recordAudit(submission, submission.getPublisher().getId(), PublishingAction.APPROVE, request.reviewedBy(),
+					"Approved submission");
+		}
+		else {
+			submission.setStatus(SubmissionStatus.REJECTED);
+			submission.setRejectionReason(request.rejectionReason());
+			recordAudit(submission, submission.getPublisher().getId(), PublishingAction.REJECT, request.reviewedBy(),
+					"Rejected submission: " + request.rejectionReason());
+		}
+		submission.setUpdatedAt(now);
+		submissionRepository.save(submission);
+
+		return toResponse(submission);
+	}
+
+	public SubmissionResponse publishRelease(String submissionId, PublishReleaseRequest request) {
+		SubmissionEntity submission = getSubmissionEntity(submissionId);
+
+		if (submission.getStatus() != SubmissionStatus.APPROVED
+				&& submission.getStatus() != SubmissionStatus.SCHEDULED) {
+			throw new IllegalStateException("Cannot publish submission in status: " + submission.getStatus());
+		}
+
+		Instant now = Instant.now();
+		if (request.scheduledAt() != null && request.scheduledAt().isAfter(now)) {
+			submission.setStatus(SubmissionStatus.SCHEDULED);
+			submission.setScheduledAt(request.scheduledAt());
+			recordAudit(submission, submission.getPublisher().getId(), PublishingAction.SCHEDULE, request.performedBy(),
+					"Scheduled release for " + request.scheduledAt());
+		}
+		else {
+			submission.setStatus(SubmissionStatus.PUBLISHED);
+			submission.setScheduledAt(now);
+			manageCatalogUseCase.updateEditionStatus(submission.getEditionId(), EditionStatus.PUBLISHED);
+			recordAudit(submission, submission.getPublisher().getId(), PublishingAction.PUBLISH, request.performedBy(),
+					"Published edition release");
+		}
+		submission.setUpdatedAt(now);
+		submissionRepository.save(submission);
+
+		return toResponse(submission);
+	}
+
+	public SubmissionResponse withdrawRelease(String submissionId, WithdrawReleaseRequest request) {
+		SubmissionEntity submission = getSubmissionEntity(submissionId);
+
+		if (submission.getStatus() != SubmissionStatus.PUBLISHED
+				&& submission.getStatus() != SubmissionStatus.SCHEDULED) {
+			throw new IllegalStateException("Cannot withdraw submission in status: " + submission.getStatus());
+		}
+
+		Instant now = Instant.now();
+		submission.setStatus(SubmissionStatus.WITHDRAWN);
+		submission.setUpdatedAt(now);
+
+		manageCatalogUseCase.updateEditionStatus(submission.getEditionId(), EditionStatus.ARCHIVED);
+		recordAudit(submission, submission.getPublisher().getId(), PublishingAction.WITHDRAW, request.performedBy(),
+				"Withdrew release: " + request.reason());
+
+		submissionRepository.save(submission);
+		return toResponse(submission);
+	}
+
+	public SubmissionResponse replaceEdition(String submissionId, ReplaceEditionRequest request) {
+		SubmissionEntity submission = getSubmissionEntity(submissionId);
+
+		String oldEditionId = submission.getEditionId();
+		submission.setEditionId(request.newEditionId());
+		submission.setUpdatedAt(Instant.now());
+
+		manageCatalogUseCase.updateEditionStatus(oldEditionId, EditionStatus.ARCHIVED);
+		manageCatalogUseCase.updateEditionStatus(request.newEditionId(), EditionStatus.PUBLISHED);
+
+		recordAudit(submission, submission.getPublisher().getId(), PublishingAction.REPLACE, request.performedBy(),
+				"Replaced edition " + oldEditionId + " with " + request.newEditionId());
+
+		submissionRepository.save(submission);
+		return toResponse(submission);
+	}
+
+	public void updateTerritoryAvailability(String editionId, UpdateAvailabilityRequest request) {
+		manageCatalogUseCase.setAvailability(editionId, request.territory(), request.availableFrom(),
+				request.availableUntil(), request.isAvailable());
+	}
+
+	@Transactional(readOnly = true)
+	public SubmissionResponse getSubmission(String submissionId) {
+		return toResponse(getSubmissionEntity(submissionId));
+	}
+
+	@Transactional(readOnly = true)
+	public List<PublishingAuditEventResponse> getSubmissionHistory(String submissionId) {
+		return auditEventRepository.findBySubmissionIdOrderByCreatedAtAsc(submissionId)
+			.stream()
+			.map(a -> new PublishingAuditEventResponse(a.getId(), a.getSubmission().getId(), a.getPublisherId(),
+					a.getAction().name(), a.getPerformedBy(), a.getDetails(), a.getCreatedAt()))
+			.toList();
+	}
+
+	private SubmissionEntity getSubmissionEntity(String submissionId) {
+		return submissionRepository.findById(submissionId)
+			.orElseThrow(() -> new IllegalArgumentException("Submission not found: " + submissionId));
+	}
+
+	private void recordAudit(SubmissionEntity submission, String publisherId, PublishingAction action,
+			String performedBy, String details) {
+		PublishingAuditEventEntity audit = new PublishingAuditEventEntity(UUID.randomUUID().toString(), submission,
+				publisherId, action, performedBy, details, Instant.now());
+		auditEventRepository.save(audit);
+	}
+
+	private SubmissionResponse toResponse(SubmissionEntity submission) {
+		return new SubmissionResponse(submission.getId(), submission.getPublisher().getId(), submission.getEditionId(),
+				submission.getTitle(), submission.getIsbn(), submission.getStatus().name(),
+				submission.getRejectionReason(), submission.getScheduledAt(), submission.getCreatedAt(),
+				submission.getUpdatedAt());
+	}
+
+}

--- a/src/main/java/dev/samster/granthalay/publishing/PublisherRepository.java
+++ b/src/main/java/dev/samster/granthalay/publishing/PublisherRepository.java
@@ -1,0 +1,7 @@
+package dev.samster.granthalay.publishing;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface PublisherRepository extends JpaRepository<PublisherEntity, String> {
+
+}

--- a/src/main/java/dev/samster/granthalay/publishing/PublisherStatus.java
+++ b/src/main/java/dev/samster/granthalay/publishing/PublisherStatus.java
@@ -1,0 +1,7 @@
+package dev.samster.granthalay.publishing;
+
+public enum PublisherStatus {
+
+	PENDING, APPROVED, SUSPENDED
+
+}

--- a/src/main/java/dev/samster/granthalay/publishing/PublishingAction.java
+++ b/src/main/java/dev/samster/granthalay/publishing/PublishingAction.java
@@ -1,0 +1,7 @@
+package dev.samster.granthalay.publishing;
+
+public enum PublishingAction {
+
+	SUBMIT, REVIEW, APPROVE, REJECT, SCHEDULE, PUBLISH, WITHDRAW, REPLACE, UPDATE_AVAILABILITY
+
+}

--- a/src/main/java/dev/samster/granthalay/publishing/PublishingAuditEventEntity.java
+++ b/src/main/java/dev/samster/granthalay/publishing/PublishingAuditEventEntity.java
@@ -1,0 +1,61 @@
+package dev.samster.granthalay.publishing;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "publishing_audit_events")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+class PublishingAuditEventEntity {
+
+	@Id
+	@Column(name = "id", nullable = false, length = 36)
+	private String id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "submission_id", nullable = false)
+	private SubmissionEntity submission;
+
+	@Column(name = "publisher_id", nullable = false, length = 36)
+	private String publisherId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "action", nullable = false, length = 50)
+	private PublishingAction action;
+
+	@Column(name = "performed_by", nullable = false)
+	private String performedBy;
+
+	@Column(name = "details", columnDefinition = "TEXT")
+	private String details;
+
+	@Column(name = "created_at", nullable = false)
+	private Instant createdAt;
+
+	PublishingAuditEventEntity(String id, SubmissionEntity submission, String publisherId, PublishingAction action,
+			String performedBy, String details, Instant createdAt) {
+		this.id = id;
+		this.submission = submission;
+		this.publisherId = publisherId;
+		this.action = action;
+		this.performedBy = performedBy;
+		this.details = details;
+		this.createdAt = createdAt;
+	}
+
+}

--- a/src/main/java/dev/samster/granthalay/publishing/PublishingAuditEventRepository.java
+++ b/src/main/java/dev/samster/granthalay/publishing/PublishingAuditEventRepository.java
@@ -1,0 +1,11 @@
+package dev.samster.granthalay.publishing;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface PublishingAuditEventRepository extends JpaRepository<PublishingAuditEventEntity, String> {
+
+	List<PublishingAuditEventEntity> findBySubmissionIdOrderByCreatedAtAsc(String submissionId);
+
+}

--- a/src/main/java/dev/samster/granthalay/publishing/PublishingAuditEventResponse.java
+++ b/src/main/java/dev/samster/granthalay/publishing/PublishingAuditEventResponse.java
@@ -1,0 +1,7 @@
+package dev.samster.granthalay.publishing;
+
+import java.time.Instant;
+
+public record PublishingAuditEventResponse(String id, String submissionId, String publisherId, String action,
+		String performedBy, String details, Instant createdAt) {
+}

--- a/src/main/java/dev/samster/granthalay/publishing/PublishingController.java
+++ b/src/main/java/dev/samster/granthalay/publishing/PublishingController.java
@@ -1,0 +1,95 @@
+package dev.samster.granthalay.publishing;
+
+import java.net.URI;
+import java.security.Principal;
+import java.util.List;
+
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/publishing")
+public class PublishingController {
+
+	private final PublisherReleaseUseCase releaseUseCase;
+
+	public PublishingController(PublisherReleaseUseCase releaseUseCase) {
+		this.releaseUseCase = releaseUseCase;
+	}
+
+	@PostMapping("/submissions")
+	public ResponseEntity<SubmissionResponse> submitEdition(@Valid @RequestBody SubmitEditionRequest request,
+			Principal principal) {
+		String performedBy = principal != null ? principal.getName() : "system";
+		SubmissionResponse response = releaseUseCase.submitEdition(request, performedBy);
+		return ResponseEntity.status(HttpStatus.CREATED).body(response);
+	}
+
+	@PostMapping("/submissions/{submissionId}/review")
+	public ResponseEntity<SubmissionResponse> reviewSubmission(@PathVariable String submissionId,
+			@Valid @RequestBody ReviewSubmissionRequest request) {
+		SubmissionResponse response = releaseUseCase.reviewSubmission(submissionId, request);
+		return ResponseEntity.ok(response);
+	}
+
+	@PostMapping("/submissions/{submissionId}/publish")
+	public ResponseEntity<SubmissionResponse> publishRelease(@PathVariable String submissionId,
+			@Valid @RequestBody PublishReleaseRequest request) {
+		SubmissionResponse response = releaseUseCase.publishRelease(submissionId, request);
+		return ResponseEntity.ok(response);
+	}
+
+	@PostMapping("/submissions/{submissionId}/withdraw")
+	public ResponseEntity<SubmissionResponse> withdrawRelease(@PathVariable String submissionId,
+			@Valid @RequestBody WithdrawReleaseRequest request) {
+		SubmissionResponse response = releaseUseCase.withdrawRelease(submissionId, request);
+		return ResponseEntity.ok(response);
+	}
+
+	@PostMapping("/submissions/{submissionId}/replace")
+	public ResponseEntity<SubmissionResponse> replaceEdition(@PathVariable String submissionId,
+			@Valid @RequestBody ReplaceEditionRequest request) {
+		SubmissionResponse response = releaseUseCase.replaceEdition(submissionId, request);
+		return ResponseEntity.ok(response);
+	}
+
+	@PutMapping("/editions/{editionId}/availability")
+	public ResponseEntity<Void> updateAvailability(@PathVariable String editionId,
+			@Valid @RequestBody UpdateAvailabilityRequest request) {
+		releaseUseCase.updateTerritoryAvailability(editionId, request);
+		return ResponseEntity.ok().build();
+	}
+
+	@GetMapping("/submissions/{submissionId}/history")
+	public ResponseEntity<List<PublishingAuditEventResponse>> getSubmissionHistory(@PathVariable String submissionId) {
+		List<PublishingAuditEventResponse> history = releaseUseCase.getSubmissionHistory(submissionId);
+		return ResponseEntity.ok(history);
+	}
+
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<ProblemDetail> handleIllegalArgumentException(IllegalArgumentException ex) {
+		var problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage());
+		problem.setType(URI.create("about:blank"));
+		problem.setTitle("Bad Request");
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problem);
+	}
+
+	@ExceptionHandler(IllegalStateException.class)
+	public ResponseEntity<ProblemDetail> handleIllegalStateException(IllegalStateException ex) {
+		var problem = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, ex.getMessage());
+		problem.setType(URI.create("about:blank"));
+		problem.setTitle("Conflict");
+		return ResponseEntity.status(HttpStatus.CONFLICT).body(problem);
+	}
+
+}

--- a/src/main/java/dev/samster/granthalay/publishing/ReplaceEditionRequest.java
+++ b/src/main/java/dev/samster/granthalay/publishing/ReplaceEditionRequest.java
@@ -1,0 +1,6 @@
+package dev.samster.granthalay.publishing;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ReplaceEditionRequest(@NotBlank String newEditionId, @NotBlank String performedBy) {
+}

--- a/src/main/java/dev/samster/granthalay/publishing/ReviewSubmissionRequest.java
+++ b/src/main/java/dev/samster/granthalay/publishing/ReviewSubmissionRequest.java
@@ -1,0 +1,6 @@
+package dev.samster.granthalay.publishing;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ReviewSubmissionRequest(boolean approve, String rejectionReason, @NotBlank String reviewedBy) {
+}

--- a/src/main/java/dev/samster/granthalay/publishing/SubmissionEntity.java
+++ b/src/main/java/dev/samster/granthalay/publishing/SubmissionEntity.java
@@ -1,0 +1,74 @@
+package dev.samster.granthalay.publishing;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "publishing_submissions")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+class SubmissionEntity {
+
+	@Id
+	@Column(name = "id", nullable = false, length = 36)
+	private String id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "publisher_id", nullable = false)
+	private PublisherEntity publisher;
+
+	@Column(name = "edition_id", nullable = false, length = 36)
+	private String editionId;
+
+	@Column(name = "title", nullable = false)
+	private String title;
+
+	@Column(name = "isbn", length = 20)
+	private String isbn;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status", nullable = false, length = 50)
+	private SubmissionStatus status;
+
+	@Column(name = "rejection_reason", columnDefinition = "TEXT")
+	private String rejectionReason;
+
+	@Column(name = "scheduled_at")
+	private Instant scheduledAt;
+
+	@Column(name = "created_at", nullable = false)
+	private Instant createdAt;
+
+	@Column(name = "updated_at", nullable = false)
+	private Instant updatedAt;
+
+	SubmissionEntity(String id, PublisherEntity publisher, String editionId, String title, String isbn,
+			SubmissionStatus status, String rejectionReason, Instant scheduledAt, Instant createdAt,
+			Instant updatedAt) {
+		this.id = id;
+		this.publisher = publisher;
+		this.editionId = editionId;
+		this.title = title;
+		this.isbn = isbn;
+		this.status = status;
+		this.rejectionReason = rejectionReason;
+		this.scheduledAt = scheduledAt;
+		this.createdAt = createdAt;
+		this.updatedAt = updatedAt;
+	}
+
+}

--- a/src/main/java/dev/samster/granthalay/publishing/SubmissionRepository.java
+++ b/src/main/java/dev/samster/granthalay/publishing/SubmissionRepository.java
@@ -1,0 +1,11 @@
+package dev.samster.granthalay.publishing;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface SubmissionRepository extends JpaRepository<SubmissionEntity, String> {
+
+	List<SubmissionEntity> findByPublisherId(String publisherId);
+
+}

--- a/src/main/java/dev/samster/granthalay/publishing/SubmissionResponse.java
+++ b/src/main/java/dev/samster/granthalay/publishing/SubmissionResponse.java
@@ -1,0 +1,7 @@
+package dev.samster.granthalay.publishing;
+
+import java.time.Instant;
+
+public record SubmissionResponse(String id, String publisherId, String editionId, String title, String isbn,
+		String status, String rejectionReason, Instant scheduledAt, Instant createdAt, Instant updatedAt) {
+}

--- a/src/main/java/dev/samster/granthalay/publishing/SubmissionStatus.java
+++ b/src/main/java/dev/samster/granthalay/publishing/SubmissionStatus.java
@@ -1,0 +1,7 @@
+package dev.samster.granthalay.publishing;
+
+public enum SubmissionStatus {
+
+	SUBMITTED, IN_REVIEW, APPROVED, REJECTED, SCHEDULED, PUBLISHED, WITHDRAWN
+
+}

--- a/src/main/java/dev/samster/granthalay/publishing/SubmitEditionRequest.java
+++ b/src/main/java/dev/samster/granthalay/publishing/SubmitEditionRequest.java
@@ -1,0 +1,7 @@
+package dev.samster.granthalay.publishing;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SubmitEditionRequest(@NotBlank String publisherId, @NotBlank String editionId, @NotBlank String title,
+		String isbn) {
+}

--- a/src/main/java/dev/samster/granthalay/publishing/UpdateAvailabilityRequest.java
+++ b/src/main/java/dev/samster/granthalay/publishing/UpdateAvailabilityRequest.java
@@ -1,0 +1,9 @@
+package dev.samster.granthalay.publishing;
+
+import java.time.Instant;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateAvailabilityRequest(@NotBlank String territory, Instant availableFrom, Instant availableUntil,
+		boolean isAvailable, @NotBlank String performedBy) {
+}

--- a/src/main/java/dev/samster/granthalay/publishing/WithdrawReleaseRequest.java
+++ b/src/main/java/dev/samster/granthalay/publishing/WithdrawReleaseRequest.java
@@ -1,0 +1,6 @@
+package dev.samster.granthalay.publishing;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record WithdrawReleaseRequest(@NotBlank String reason, @NotBlank String performedBy) {
+}

--- a/src/main/java/dev/samster/granthalay/publishing/package-info.java
+++ b/src/main/java/dev/samster/granthalay/publishing/package-info.java
@@ -1,5 +1,5 @@
 /**
  * Publisher operations.
  */
-@org.springframework.modulith.ApplicationModule(allowedDependencies = {})
+@org.springframework.modulith.ApplicationModule(allowedDependencies = { "catalog" })
 package dev.samster.granthalay.publishing;

--- a/src/main/resources/db/migration/V6__publishing_schema.sql
+++ b/src/main/resources/db/migration/V6__publishing_schema.sql
@@ -1,0 +1,44 @@
+CREATE TABLE publishing_publishers (
+	id VARCHAR(36) NOT NULL,
+	name VARCHAR(255) NOT NULL,
+	status VARCHAR(50) NOT NULL,
+	contact_email VARCHAR(255) NOT NULL,
+	created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+	updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+	CONSTRAINT pk_publishing_publishers PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_publishing_publishers_status ON publishing_publishers (status);
+
+CREATE TABLE publishing_submissions (
+	id VARCHAR(36) NOT NULL,
+	publisher_id VARCHAR(36) NOT NULL,
+	edition_id VARCHAR(36) NOT NULL,
+	title VARCHAR(255) NOT NULL,
+	isbn VARCHAR(20),
+	status VARCHAR(50) NOT NULL,
+	rejection_reason TEXT,
+	scheduled_at TIMESTAMP WITH TIME ZONE,
+	created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+	updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+	CONSTRAINT pk_publishing_submissions PRIMARY KEY (id),
+	CONSTRAINT fk_publishing_submissions_publisher FOREIGN KEY (publisher_id) REFERENCES publishing_publishers (id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_publishing_submissions_publisher ON publishing_submissions (publisher_id);
+CREATE INDEX idx_publishing_submissions_edition ON publishing_submissions (edition_id);
+CREATE INDEX idx_publishing_submissions_status ON publishing_submissions (status);
+
+CREATE TABLE publishing_audit_events (
+	id VARCHAR(36) NOT NULL,
+	submission_id VARCHAR(36) NOT NULL,
+	publisher_id VARCHAR(36) NOT NULL,
+	action VARCHAR(50) NOT NULL,
+	performed_by VARCHAR(255) NOT NULL,
+	details TEXT,
+	created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+	CONSTRAINT pk_publishing_audit_events PRIMARY KEY (id),
+	CONSTRAINT fk_publishing_audit_events_submission FOREIGN KEY (submission_id) REFERENCES publishing_submissions (id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_publishing_audit_events_submission ON publishing_audit_events (submission_id);

--- a/src/main/resources/static/openapi/granthalay-api-v1.yaml
+++ b/src/main/resources/static/openapi/granthalay-api-v1.yaml
@@ -16,6 +16,8 @@ tags:
     description: User account registration, email verification, and session sign-in.
   - name: Catalog
     description: Book catalog metadata, titles, editions, and availability.
+  - name: Publishing
+    description: Publisher onboarding, submission review, release publishing, withdrawal, and replacement.
 paths:
   /api/v1:
     get:
@@ -268,6 +270,220 @@ paths:
               schema:
                 $ref: '#/components/schemas/CatalogEditionResponse'
         '404':
+          $ref: '#/components/responses/Problem'
+        '500':
+          $ref: '#/components/responses/Problem'
+  /api/v1/publishing/submissions:
+    post:
+      tags: [Publishing]
+      operationId: submitEdition
+      summary: Submit a catalog edition for publisher review
+      security:
+        - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubmitEditionRequest'
+      responses:
+        '201':
+          description: Submission created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubmissionResponse'
+        '400':
+          $ref: '#/components/responses/ValidationProblem'
+        '401':
+          $ref: '#/components/responses/Problem'
+        '500':
+          $ref: '#/components/responses/Problem'
+  /api/v1/publishing/submissions/{submissionId}/review:
+    post:
+      tags: [Publishing]
+      operationId: reviewSubmission
+      summary: Approve or reject a submitted edition
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: submissionId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReviewSubmissionRequest'
+      responses:
+        '200':
+          description: Submission review recorded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubmissionResponse'
+        '400':
+          $ref: '#/components/responses/ValidationProblem'
+        '401':
+          $ref: '#/components/responses/Problem'
+        '409':
+          $ref: '#/components/responses/Problem'
+        '500':
+          $ref: '#/components/responses/Problem'
+  /api/v1/publishing/submissions/{submissionId}/publish:
+    post:
+      tags: [Publishing]
+      operationId: publishRelease
+      summary: Publish or schedule a release for an approved edition
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: submissionId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PublishReleaseRequest'
+      responses:
+        '200':
+          description: Release published or scheduled.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubmissionResponse'
+        '400':
+          $ref: '#/components/responses/ValidationProblem'
+        '401':
+          $ref: '#/components/responses/Problem'
+        '409':
+          $ref: '#/components/responses/Problem'
+        '500':
+          $ref: '#/components/responses/Problem'
+  /api/v1/publishing/submissions/{submissionId}/withdraw:
+    post:
+      tags: [Publishing]
+      operationId: withdrawRelease
+      summary: Withdraw a published or scheduled edition release
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: submissionId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WithdrawReleaseRequest'
+      responses:
+        '200':
+          description: Release withdrawn.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubmissionResponse'
+        '400':
+          $ref: '#/components/responses/ValidationProblem'
+        '401':
+          $ref: '#/components/responses/Problem'
+        '409':
+          $ref: '#/components/responses/Problem'
+        '500':
+          $ref: '#/components/responses/Problem'
+  /api/v1/publishing/submissions/{submissionId}/replace:
+    post:
+      tags: [Publishing]
+      operationId: replaceEdition
+      summary: Replace an edition version in a submission
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: submissionId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReplaceEditionRequest'
+      responses:
+        '200':
+          description: Edition replaced.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubmissionResponse'
+        '400':
+          $ref: '#/components/responses/ValidationProblem'
+        '401':
+          $ref: '#/components/responses/Problem'
+        '500':
+          $ref: '#/components/responses/Problem'
+  /api/v1/publishing/editions/{editionId}/availability:
+    put:
+      tags: [Publishing]
+      operationId: updateAvailability
+      summary: Update territory availability for an edition
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: editionId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateAvailabilityRequest'
+      responses:
+        '200':
+          description: Territory availability updated.
+        '400':
+          $ref: '#/components/responses/ValidationProblem'
+        '401':
+          $ref: '#/components/responses/Problem'
+        '500':
+          $ref: '#/components/responses/Problem'
+  /api/v1/publishing/submissions/{submissionId}/history:
+    get:
+      tags: [Publishing]
+      operationId: getSubmissionHistory
+      summary: Fetch audit log history for a submission
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: submissionId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: List of audit log history events.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PublishingAuditEventResponse'
+        '401':
           $ref: '#/components/responses/Problem'
         '500':
           $ref: '#/components/responses/Problem'
@@ -615,4 +831,121 @@ components:
         totalPages:
           type: integer
           format: int32
+    SubmitEditionRequest:
+      type: object
+      additionalProperties: false
+      required: [publisherId, editionId, title]
+      properties:
+        publisherId:
+          type: string
+        editionId:
+          type: string
+        title:
+          type: string
+        isbn:
+          type: string
+    ReviewSubmissionRequest:
+      type: object
+      additionalProperties: false
+      required: [approve, reviewedBy]
+      properties:
+        approve:
+          type: boolean
+        rejectionReason:
+          type: string
+        reviewedBy:
+          type: string
+    PublishReleaseRequest:
+      type: object
+      additionalProperties: false
+      required: [performedBy]
+      properties:
+        scheduledAt:
+          type: string
+          format: date-time
+        performedBy:
+          type: string
+    WithdrawReleaseRequest:
+      type: object
+      additionalProperties: false
+      required: [reason, performedBy]
+      properties:
+        reason:
+          type: string
+        performedBy:
+          type: string
+    ReplaceEditionRequest:
+      type: object
+      additionalProperties: false
+      required: [newEditionId, performedBy]
+      properties:
+        newEditionId:
+          type: string
+        performedBy:
+          type: string
+    UpdateAvailabilityRequest:
+      type: object
+      additionalProperties: false
+      required: [territory, isAvailable, performedBy]
+      properties:
+        territory:
+          type: string
+        availableFrom:
+          type: string
+          format: date-time
+        availableUntil:
+          type: string
+          format: date-time
+        isAvailable:
+          type: boolean
+        performedBy:
+          type: string
+    SubmissionResponse:
+      type: object
+      additionalProperties: false
+      required: [id, publisherId, editionId, title, status, createdAt, updatedAt]
+      properties:
+        id:
+          type: string
+        publisherId:
+          type: string
+        editionId:
+          type: string
+        title:
+          type: string
+        isbn:
+          type: string
+        status:
+          type: string
+        rejectionReason:
+          type: string
+        scheduledAt:
+          type: string
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    PublishingAuditEventResponse:
+      type: object
+      additionalProperties: false
+      required: [id, submissionId, publisherId, action, performedBy, createdAt]
+      properties:
+        id:
+          type: string
+        submissionId:
+          type: string
+        publisherId:
+          type: string
+        action:
+          type: string
+        performedBy:
+          type: string
+        details:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
 

--- a/src/test/java/dev/samster/granthalay/DatabaseIT.java
+++ b/src/test/java/dev/samster/granthalay/DatabaseIT.java
@@ -36,7 +36,7 @@ class DatabaseIT {
 	@Test
 	void migrationsAreAppliedAndDoNotRepeat() {
 		flyway.validate();
-		assertThat(flyway.info().applied()).hasSize(5);
+		assertThat(flyway.info().applied()).hasSize(6);
 
 		assertThat(flyway.info().pending()).isEmpty();
 		assertThat(flyway.migrate().migrationsExecuted).isZero();

--- a/src/test/java/dev/samster/granthalay/catalog/CatalogIT.java
+++ b/src/test/java/dev/samster/granthalay/catalog/CatalogIT.java
@@ -51,16 +51,15 @@ class CatalogIT {
 		client = HttpClient.newHttpClient();
 		titleSlug = "the-god-of-small-things-" + System.currentTimeMillis();
 
-		var contributor = manageCatalogUseCase.createContributor("Arundhati Roy",
+		var contributorId = manageCatalogUseCase.createContributor("Arundhati Roy",
 				"Indian author and political activist.");
-		var title = manageCatalogUseCase.createTitle(titleSlug, "The God of Small Things", "A Novel",
+		var titleId = manageCatalogUseCase.createTitle(titleSlug, "The God of Small Things", "A Novel",
 				"A story about the childhood experiences of fraternal twins...", "en");
 
-		manageCatalogUseCase.addContributorToTitle(title.getId(), contributor.getId(), ContributorRole.AUTHOR, 1);
+		manageCatalogUseCase.addContributorToTitle(titleId, contributorId, ContributorRole.AUTHOR, 1);
 
-		var edition = manageCatalogUseCase.addEdition(title.getId(), "9780679457312", EditionFormat.EPUB, 1, null,
+		editionId = manageCatalogUseCase.addEdition(titleId, "9780679457312", EditionFormat.EPUB, 1, null,
 				LocalDate.of(1997, 4, 4), EditionStatus.PUBLISHED);
-		editionId = edition.getId();
 
 		manageCatalogUseCase.setPrice(editionId, "USD", 1499, "GLOBAL");
 		manageCatalogUseCase.setPrice(editionId, "INR", 49900, "IN");

--- a/src/test/java/dev/samster/granthalay/publishing/PublishingIT.java
+++ b/src/test/java/dev/samster/granthalay/publishing/PublishingIT.java
@@ -1,0 +1,106 @@
+package dev.samster.granthalay.publishing;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+import dev.samster.granthalay.TestcontainersConfiguration;
+import dev.samster.granthalay.catalog.EditionFormat;
+import dev.samster.granthalay.catalog.EditionStatus;
+import dev.samster.granthalay.catalog.ManageCatalogUseCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+@Transactional
+class PublishingIT {
+
+	@Autowired
+	PublisherReleaseUseCase releaseUseCase;
+
+	@Autowired
+	ManageCatalogUseCase manageCatalogUseCase;
+
+	@Autowired
+	PublisherRepository publisherRepository;
+
+	@Autowired
+	SubmissionRepository submissionRepository;
+
+	@Autowired
+	PublishingAuditEventRepository auditEventRepository;
+
+	private PublisherEntity publisher;
+
+	private String editionId;
+
+	@BeforeEach
+	void setUp() {
+		publisher = releaseUseCase.createPublisher("Penguin Random House", "contact@penguin.example");
+
+		var titleId = manageCatalogUseCase.createTitle("1984-george-orwell-" + System.currentTimeMillis(), "1984",
+				"A Novel", "Dystopian social science fiction novel", "en");
+
+		editionId = manageCatalogUseCase.addEdition(titleId, "9780451524935", EditionFormat.EPUB, 1, publisher.getId(),
+				LocalDate.of(1949, 6, 8), EditionStatus.DRAFT);
+	}
+
+	@Test
+	void executesFullSubmissionLifecycleSubmitApprovePublishWithdraw() {
+		// 1. Submit Edition
+		SubmitEditionRequest submitReq = new SubmitEditionRequest(publisher.getId(), editionId, "1984",
+				"9780451524935");
+		SubmissionResponse sub = releaseUseCase.submitEdition(submitReq, "publisher-admin");
+		assertThat(sub.status()).isEqualTo("SUBMITTED");
+
+		// 2. Review & Approve
+		ReviewSubmissionRequest reviewReq = new ReviewSubmissionRequest(true, null, "reviewer-1");
+		sub = releaseUseCase.reviewSubmission(sub.id(), reviewReq);
+		assertThat(sub.status()).isEqualTo("APPROVED");
+
+		// 3. Publish Release
+		PublishReleaseRequest publishReq = new PublishReleaseRequest(null, "publisher-admin");
+		sub = releaseUseCase.publishRelease(sub.id(), publishReq);
+		assertThat(sub.status()).isEqualTo("PUBLISHED");
+
+		// 4. Update Territory Availability
+		UpdateAvailabilityRequest availReq = new UpdateAvailabilityRequest("GLOBAL", Instant.now(), null, true,
+				"publisher-admin");
+		releaseUseCase.updateTerritoryAvailability(editionId, availReq);
+
+		// 5. Withdraw Release
+		WithdrawReleaseRequest withdrawReq = new WithdrawReleaseRequest("Rights expired", "publisher-admin");
+		sub = releaseUseCase.withdrawRelease(sub.id(), withdrawReq);
+		assertThat(sub.status()).isEqualTo("WITHDRAWN");
+
+		// 6. Audit Trail Verification
+		List<PublishingAuditEventResponse> history = releaseUseCase.getSubmissionHistory(sub.id());
+		assertThat(history).hasSize(4);
+		assertThat(history.get(0).action()).isEqualTo("SUBMIT");
+		assertThat(history.get(1).action()).isEqualTo("APPROVE");
+		assertThat(history.get(2).action()).isEqualTo("PUBLISH");
+		assertThat(history.get(3).action()).isEqualTo("WITHDRAW");
+	}
+
+	@Test
+	void rejectsInvalidStateTransitions() {
+		SubmitEditionRequest submitReq = new SubmitEditionRequest(publisher.getId(), editionId, "1984",
+				"9780451524935");
+		SubmissionResponse sub = releaseUseCase.submitEdition(submitReq, "publisher-admin");
+
+		// Cannot publish directly from SUBMITTED state without approval
+		PublishReleaseRequest publishReq = new PublishReleaseRequest(null, "publisher-admin");
+		assertThatThrownBy(() -> releaseUseCase.publishRelease(sub.id(), publishReq))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("Cannot publish submission in status: SUBMITTED");
+	}
+
+}


### PR DESCRIPTION
## Summary of Changes

Implements publisher release workflows, state machine transitions (review, scheduled publication, withdrawal, edition replacement, territory availability), auditable state event history, catalog module synchronization, and REST endpoints for issue #4.

### 1. Database Schema & Flyway Migration (`V6__publishing_schema.sql`)
- Created PostgreSQL tables: `publishing_publishers`, `publishing_submissions`, and `publishing_audit_events`.
- Foreign key constraints, state indexes, rejection reasons, scheduled publication timestamps, and audit event logs.

### 2. Publishing Module Implementation (`dev.samster.granthalay.publishing`)
- **Package Configuration**: Updated `package-info.java` with `allowedDependencies = {"catalog"}`.
- **Entities & Enums**: `PublisherEntity`, `SubmissionEntity`, `PublishingAuditEventEntity`, `PublisherStatus`, `SubmissionStatus`, `PublishingAction`.
- **Repositories**: `PublisherRepository`, `SubmissionRepository`, `PublishingAuditEventRepository`.
- **Application Services & DTOs**: `PublisherReleaseUseCase` implementing submission lifecycle, review, immediate/scheduled publishing, release withdrawal, edition replacement, and audit log generation.
- **REST Controller**: `PublishingController` exposing authenticated endpoints under `/api/v1/publishing` for submission workflow operations and audit history.

### 3. Security & OpenAPI
- Required authentication for `/api/v1/publishing/**` in `SecurityConfiguration`.
- Added `Publishing` tag, paths, and component schemas to `granthalay-api-v1.yaml`.

### 4. Testing & Verification
- Created `PublishingIT` integration test suite covering full submission lifecycle, invalid state transition rejections, territory availability updates, and audit trail verification.
- Updated `DatabaseIT` to validate 6 applied Flyway migrations.
- Executed `./mvnw verify` with clean success.

Closes #4
