### PR TITLE
Publishing: Build publisher onboarding and metadata submission

### DIFF
--- a/docs/08-modules-and-roadmap.md
+++ b/docs/08-modules-and-roadmap.md
@@ -73,8 +73,8 @@ flowchart TD
 
 ### Phase 4: Protected Delivery & Publishing
 - [x] Implement `storage` module: Secure EPUB ingestion, validation, versioning, and object storage (Issue #9).
+- [x] Implement `publishing` module: Publisher onboarding, team member roles, payout references, and metadata submission (Issue #13).
 - [ ] Implement `delivery` module: Streamed EPUB content delivery.
-- [ ] Implement `publishing` module: Publisher dashboard & submission pipeline.
 
 ---
 

--- a/src/main/java/dev/samster/granthalay/publishing/AddPublisherMemberRequest.java
+++ b/src/main/java/dev/samster/granthalay/publishing/AddPublisherMemberRequest.java
@@ -1,0 +1,6 @@
+package dev.samster.granthalay.publishing;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AddPublisherMemberRequest(@NotBlank String userId, @NotBlank String role) {
+}

--- a/src/main/java/dev/samster/granthalay/publishing/OnboardPublisherRequest.java
+++ b/src/main/java/dev/samster/granthalay/publishing/OnboardPublisherRequest.java
@@ -1,0 +1,8 @@
+package dev.samster.granthalay.publishing;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record OnboardPublisherRequest(@NotBlank String name, @NotBlank @Email String contactEmail,
+		String payoutReference) {
+}

--- a/src/main/java/dev/samster/granthalay/publishing/PublisherEntity.java
+++ b/src/main/java/dev/samster/granthalay/publishing/PublisherEntity.java
@@ -34,20 +34,29 @@ class PublisherEntity {
 	@Column(name = "contact_email", nullable = false)
 	private String contactEmail;
 
+	@Column(name = "payout_reference")
+	private String payoutReference;
+
 	@Column(name = "created_at", nullable = false)
 	private Instant createdAt;
 
 	@Column(name = "updated_at", nullable = false)
 	private Instant updatedAt;
 
-	PublisherEntity(String id, String name, PublisherStatus status, String contactEmail, Instant createdAt,
-			Instant updatedAt) {
+	PublisherEntity(String id, String name, PublisherStatus status, String contactEmail, String payoutReference,
+			Instant createdAt, Instant updatedAt) {
 		this.id = id;
 		this.name = name;
 		this.status = status;
 		this.contactEmail = contactEmail;
+		this.payoutReference = payoutReference;
 		this.createdAt = createdAt;
 		this.updatedAt = updatedAt;
+	}
+
+	PublisherEntity(String id, String name, PublisherStatus status, String contactEmail, Instant createdAt,
+			Instant updatedAt) {
+		this(id, name, status, contactEmail, null, createdAt, updatedAt);
 	}
 
 }

--- a/src/main/java/dev/samster/granthalay/publishing/PublisherMemberEntity.java
+++ b/src/main/java/dev/samster/granthalay/publishing/PublisherMemberEntity.java
@@ -1,0 +1,53 @@
+package dev.samster.granthalay.publishing;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "publishing_publisher_members")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+class PublisherMemberEntity {
+
+	@Id
+	@Column(name = "id", nullable = false, length = 36)
+	private String id;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "publisher_id", nullable = false)
+	private PublisherEntity publisher;
+
+	@Column(name = "user_id", nullable = false, length = 36)
+	private String userId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "role", nullable = false, length = 50)
+	private PublisherMemberRole role;
+
+	@Column(name = "created_at", nullable = false)
+	private Instant createdAt;
+
+	PublisherMemberEntity(String id, PublisherEntity publisher, String userId, PublisherMemberRole role,
+			Instant createdAt) {
+		this.id = id;
+		this.publisher = publisher;
+		this.userId = userId;
+		this.role = role;
+		this.createdAt = createdAt;
+	}
+
+}

--- a/src/main/java/dev/samster/granthalay/publishing/PublisherMemberRepository.java
+++ b/src/main/java/dev/samster/granthalay/publishing/PublisherMemberRepository.java
@@ -1,0 +1,20 @@
+package dev.samster.granthalay.publishing;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+interface PublisherMemberRepository extends JpaRepository<PublisherMemberEntity, String> {
+
+	List<PublisherMemberEntity> findByUserId(String userId);
+
+	List<PublisherMemberEntity> findByPublisherId(String publisherId);
+
+	Optional<PublisherMemberEntity> findByPublisherIdAndUserId(String publisherId, String userId);
+
+	boolean existsByPublisherIdAndUserId(String publisherId, String userId);
+
+}

--- a/src/main/java/dev/samster/granthalay/publishing/PublisherMemberResponse.java
+++ b/src/main/java/dev/samster/granthalay/publishing/PublisherMemberResponse.java
@@ -1,0 +1,6 @@
+package dev.samster.granthalay.publishing;
+
+import java.time.Instant;
+
+public record PublisherMemberResponse(String id, String publisherId, String userId, String role, Instant createdAt) {
+}

--- a/src/main/java/dev/samster/granthalay/publishing/PublisherMemberRole.java
+++ b/src/main/java/dev/samster/granthalay/publishing/PublisherMemberRole.java
@@ -1,0 +1,7 @@
+package dev.samster.granthalay.publishing;
+
+public enum PublisherMemberRole {
+
+	OWNER, EDITOR, ADMIN
+
+}

--- a/src/main/java/dev/samster/granthalay/publishing/PublisherOnboardingUseCase.java
+++ b/src/main/java/dev/samster/granthalay/publishing/PublisherOnboardingUseCase.java
@@ -1,0 +1,116 @@
+package dev.samster.granthalay.publishing;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class PublisherOnboardingUseCase {
+
+	private final PublisherRepository publisherRepository;
+
+	private final PublisherMemberRepository memberRepository;
+
+	PublisherOnboardingUseCase(PublisherRepository publisherRepository, PublisherMemberRepository memberRepository) {
+		this.publisherRepository = publisherRepository;
+		this.memberRepository = memberRepository;
+	}
+
+	public PublisherResponse onboardPublisher(OnboardPublisherRequest request, String userId) {
+		if (userId == null || userId.isBlank()) {
+			throw new IllegalArgumentException("User ID is required for publisher onboarding");
+		}
+
+		Instant now = Instant.now();
+		PublisherEntity publisher = new PublisherEntity(UUID.randomUUID().toString(), request.name(),
+				PublisherStatus.APPROVED, request.contactEmail(), request.payoutReference(), now, now);
+		PublisherEntity savedPublisher = publisherRepository.save(publisher);
+
+		PublisherMemberEntity member = new PublisherMemberEntity(UUID.randomUUID().toString(), savedPublisher, userId,
+				PublisherMemberRole.OWNER, now);
+		memberRepository.save(member);
+
+		return toPublisherResponse(savedPublisher);
+	}
+
+	@Transactional(readOnly = true)
+	public List<PublisherResponse> getPublishersForUser(String userId) {
+		if (userId == null || userId.isBlank()) {
+			throw new IllegalArgumentException("User ID is required");
+		}
+
+		return memberRepository.findByUserId(userId)
+			.stream()
+			.map(PublisherMemberEntity::getPublisher)
+			.map(this::toPublisherResponse)
+			.toList();
+	}
+
+	@Transactional(readOnly = true)
+	public PublisherResponse getPublisherProfile(String publisherId, String requestingUserId) {
+		PublisherEntity publisher = getPublisherAndVerifyAccess(publisherId, requestingUserId);
+		return toPublisherResponse(publisher);
+	}
+
+	public PublisherResponse updatePublisherProfile(String publisherId, UpdatePublisherProfileRequest request,
+			String requestingUserId) {
+		PublisherEntity publisher = getPublisherAndVerifyAccess(publisherId, requestingUserId);
+
+		publisher.setName(request.name());
+		publisher.setContactEmail(request.contactEmail());
+		publisher.setPayoutReference(request.payoutReference());
+		publisher.setUpdatedAt(Instant.now());
+
+		PublisherEntity updated = publisherRepository.save(publisher);
+		return toPublisherResponse(updated);
+	}
+
+	public PublisherMemberResponse addPublisherMember(String publisherId, AddPublisherMemberRequest request,
+			String requestingUserId) {
+		PublisherEntity publisher = getPublisherAndVerifyAccess(publisherId, requestingUserId);
+
+		if (memberRepository.existsByPublisherIdAndUserId(publisherId, request.userId())) {
+			throw new IllegalStateException("User " + request.userId() + " is already a member of this publisher");
+		}
+
+		PublisherMemberRole role;
+		try {
+			role = PublisherMemberRole.valueOf(request.role().toUpperCase());
+		}
+		catch (Exception e) {
+			throw new IllegalArgumentException("Invalid member role: " + request.role());
+		}
+
+		Instant now = Instant.now();
+		PublisherMemberEntity member = new PublisherMemberEntity(UUID.randomUUID().toString(), publisher,
+				request.userId(), role, now);
+		PublisherMemberEntity saved = memberRepository.save(member);
+
+		return new PublisherMemberResponse(saved.getId(), saved.getPublisher().getId(), saved.getUserId(),
+				saved.getRole().name(), saved.getCreatedAt());
+	}
+
+	private PublisherEntity getPublisherAndVerifyAccess(String publisherId, String userId) {
+		PublisherEntity publisher = publisherRepository.findById(publisherId)
+			.orElseThrow(() -> new IllegalArgumentException("Publisher not found: " + publisherId));
+
+		boolean isMember = memberRepository.existsByPublisherIdAndUserId(publisherId, userId);
+		if (!isMember) {
+			throw new IllegalArgumentException(
+					"User " + userId + " is not authorized to access publisher: " + publisherId);
+		}
+
+		return publisher;
+	}
+
+	private PublisherResponse toPublisherResponse(PublisherEntity publisher) {
+		return new PublisherResponse(publisher.getId(), publisher.getName(), publisher.getStatus().name(),
+				publisher.getContactEmail(), publisher.getPayoutReference(), publisher.getCreatedAt(),
+				publisher.getUpdatedAt());
+	}
+
+}

--- a/src/main/java/dev/samster/granthalay/publishing/PublisherResponse.java
+++ b/src/main/java/dev/samster/granthalay/publishing/PublisherResponse.java
@@ -1,0 +1,7 @@
+package dev.samster.granthalay.publishing;
+
+import java.time.Instant;
+
+public record PublisherResponse(String id, String name, String status, String contactEmail, String payoutReference,
+		Instant createdAt, Instant updatedAt) {
+}

--- a/src/main/java/dev/samster/granthalay/publishing/PublishingController.java
+++ b/src/main/java/dev/samster/granthalay/publishing/PublishingController.java
@@ -23,8 +23,49 @@ public class PublishingController {
 
 	private final PublisherReleaseUseCase releaseUseCase;
 
-	public PublishingController(PublisherReleaseUseCase releaseUseCase) {
+	private final PublisherOnboardingUseCase onboardingUseCase;
+
+	public PublishingController(PublisherReleaseUseCase releaseUseCase, PublisherOnboardingUseCase onboardingUseCase) {
 		this.releaseUseCase = releaseUseCase;
+		this.onboardingUseCase = onboardingUseCase;
+	}
+
+	@PostMapping("/publishers/onboard")
+	public ResponseEntity<PublisherResponse> onboardPublisher(@Valid @RequestBody OnboardPublisherRequest request,
+			Principal principal) {
+		String userId = principal != null ? principal.getName() : "system";
+		PublisherResponse response = onboardingUseCase.onboardPublisher(request, userId);
+		return ResponseEntity.status(HttpStatus.CREATED).body(response);
+	}
+
+	@GetMapping("/publishers/me")
+	public ResponseEntity<List<PublisherResponse>> getMyPublishers(Principal principal) {
+		String userId = principal != null ? principal.getName() : "system";
+		List<PublisherResponse> publishers = onboardingUseCase.getPublishersForUser(userId);
+		return ResponseEntity.ok(publishers);
+	}
+
+	@GetMapping("/publishers/{publisherId}")
+	public ResponseEntity<PublisherResponse> getPublisherById(@PathVariable String publisherId, Principal principal) {
+		String userId = principal != null ? principal.getName() : "system";
+		PublisherResponse publisher = onboardingUseCase.getPublisherProfile(publisherId, userId);
+		return ResponseEntity.ok(publisher);
+	}
+
+	@PutMapping("/publishers/{publisherId}")
+	public ResponseEntity<PublisherResponse> updatePublisherProfile(@PathVariable String publisherId,
+			@Valid @RequestBody UpdatePublisherProfileRequest request, Principal principal) {
+		String userId = principal != null ? principal.getName() : "system";
+		PublisherResponse publisher = onboardingUseCase.updatePublisherProfile(publisherId, request, userId);
+		return ResponseEntity.ok(publisher);
+	}
+
+	@PostMapping("/publishers/{publisherId}/members")
+	public ResponseEntity<PublisherMemberResponse> addPublisherMember(@PathVariable String publisherId,
+			@Valid @RequestBody AddPublisherMemberRequest request, Principal principal) {
+		String userId = principal != null ? principal.getName() : "system";
+		PublisherMemberResponse member = onboardingUseCase.addPublisherMember(publisherId, request, userId);
+		return ResponseEntity.status(HttpStatus.CREATED).body(member);
 	}
 
 	@PostMapping("/submissions")

--- a/src/main/java/dev/samster/granthalay/publishing/UpdatePublisherProfileRequest.java
+++ b/src/main/java/dev/samster/granthalay/publishing/UpdatePublisherProfileRequest.java
@@ -1,0 +1,8 @@
+package dev.samster.granthalay.publishing;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdatePublisherProfileRequest(@NotBlank String name, @NotBlank @Email String contactEmail,
+		String payoutReference) {
+}

--- a/src/main/resources/db/migration/V8__publisher_onboarding_schema.sql
+++ b/src/main/resources/db/migration/V8__publisher_onboarding_schema.sql
@@ -1,0 +1,15 @@
+ALTER TABLE publishing_publishers ADD COLUMN payout_reference VARCHAR(255);
+
+CREATE TABLE publishing_publisher_members (
+	id VARCHAR(36) NOT NULL,
+	publisher_id VARCHAR(36) NOT NULL,
+	user_id VARCHAR(36) NOT NULL,
+	role VARCHAR(50) NOT NULL,
+	created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+	CONSTRAINT pk_publishing_publisher_members PRIMARY KEY (id),
+	CONSTRAINT fk_publishing_publisher_members_publisher FOREIGN KEY (publisher_id) REFERENCES publishing_publishers (id) ON DELETE CASCADE,
+	CONSTRAINT uq_publishing_publisher_members UNIQUE (publisher_id, user_id)
+);
+
+CREATE INDEX idx_publishing_publisher_members_publisher ON publishing_publisher_members (publisher_id);
+CREATE INDEX idx_publishing_publisher_members_user ON publishing_publisher_members (user_id);

--- a/src/main/resources/static/openapi/granthalay-api-v1.yaml
+++ b/src/main/resources/static/openapi/granthalay-api-v1.yaml
@@ -489,6 +489,145 @@ paths:
           $ref: '#/components/responses/Problem'
         '500':
           $ref: '#/components/responses/Problem'
+  /api/v1/publishing/publishers/onboard:
+    post:
+      tags: [Publishing]
+      operationId: onboardPublisher
+      summary: Onboard a new publisher profile
+      security:
+        - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OnboardPublisherRequest'
+      responses:
+        '201':
+          description: Publisher profile created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublisherResponse'
+        '400':
+          $ref: '#/components/responses/ValidationProblem'
+        '401':
+          $ref: '#/components/responses/Problem'
+        '500':
+          $ref: '#/components/responses/Problem'
+  /api/v1/publishing/publishers/me:
+    get:
+      tags: [Publishing]
+      operationId: getMyPublishers
+      summary: List publisher profiles associated with current user
+      security:
+        - sessionCookie: []
+      responses:
+        '200':
+          description: List of associated publisher profiles.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PublisherResponse'
+        '401':
+          $ref: '#/components/responses/Problem'
+        '500':
+          $ref: '#/components/responses/Problem'
+  /api/v1/publishing/publishers/{publisherId}:
+    get:
+      tags: [Publishing]
+      operationId: getPublisherById
+      summary: Fetch publisher profile details by ID
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: publisherId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Publisher profile details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublisherResponse'
+        '401':
+          $ref: '#/components/responses/Problem'
+        '404':
+          $ref: '#/components/responses/Problem'
+        '500':
+          $ref: '#/components/responses/Problem'
+    put:
+      tags: [Publishing]
+      operationId: updatePublisherProfile
+      summary: Update publisher profile details
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: publisherId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdatePublisherProfileRequest'
+      responses:
+        '200':
+          description: Publisher profile updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublisherResponse'
+        '400':
+          $ref: '#/components/responses/ValidationProblem'
+        '401':
+          $ref: '#/components/responses/Problem'
+        '404':
+          $ref: '#/components/responses/Problem'
+        '500':
+          $ref: '#/components/responses/Problem'
+  /api/v1/publishing/publishers/{publisherId}/members:
+    post:
+      tags: [Publishing]
+      operationId: addPublisherMember
+      summary: Add a team member to a publisher profile
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: publisherId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddPublisherMemberRequest'
+      responses:
+        '201':
+          description: Publisher team member added.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublisherMemberResponse'
+        '400':
+          $ref: '#/components/responses/ValidationProblem'
+        '401':
+          $ref: '#/components/responses/Problem'
+        '404':
+          $ref: '#/components/responses/Problem'
+        '500':
+          $ref: '#/components/responses/Problem'
   /api/v1/storage/epubs/{editionId}:
     post:
       tags: [Storage]
@@ -1041,5 +1180,74 @@ components:
         createdAt:
           type: string
           format: date-time
+    OnboardPublisherRequest:
+      type: object
+      additionalProperties: false
+      required: [name, contactEmail]
+      properties:
+        name:
+          type: string
+        contactEmail:
+          type: string
+        payoutReference:
+          type: string
+    UpdatePublisherProfileRequest:
+      type: object
+      additionalProperties: false
+      required: [name, contactEmail]
+      properties:
+        name:
+          type: string
+        contactEmail:
+          type: string
+        payoutReference:
+          type: string
+    AddPublisherMemberRequest:
+      type: object
+      additionalProperties: false
+      required: [userId, role]
+      properties:
+        userId:
+          type: string
+        role:
+          type: string
+    PublisherResponse:
+      type: object
+      additionalProperties: false
+      required: [id, name, status, contactEmail, createdAt, updatedAt]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        status:
+          type: string
+        contactEmail:
+          type: string
+        payoutReference:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    PublisherMemberResponse:
+      type: object
+      additionalProperties: false
+      required: [id, publisherId, userId, role, createdAt]
+      properties:
+        id:
+          type: string
+        publisherId:
+          type: string
+        userId:
+          type: string
+        role:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+
 
 

--- a/src/test/java/dev/samster/granthalay/DatabaseIT.java
+++ b/src/test/java/dev/samster/granthalay/DatabaseIT.java
@@ -36,7 +36,7 @@ class DatabaseIT {
 	@Test
 	void migrationsAreAppliedAndDoNotRepeat() {
 		flyway.validate();
-		assertThat(flyway.info().applied()).hasSize(7);
+		assertThat(flyway.info().applied()).hasSize(8);
 
 		assertThat(flyway.info().pending()).isEmpty();
 		assertThat(flyway.migrate().migrationsExecuted).isZero();

--- a/src/test/java/dev/samster/granthalay/publishing/PublishingIT.java
+++ b/src/test/java/dev/samster/granthalay/publishing/PublishingIT.java
@@ -27,6 +27,9 @@ class PublishingIT {
 	PublisherReleaseUseCase releaseUseCase;
 
 	@Autowired
+	PublisherOnboardingUseCase onboardingUseCase;
+
+	@Autowired
 	ManageCatalogUseCase manageCatalogUseCase;
 
 	@Autowired
@@ -101,6 +104,46 @@ class PublishingIT {
 		assertThatThrownBy(() -> releaseUseCase.publishRelease(sub.id(), publishReq))
 			.isInstanceOf(IllegalStateException.class)
 			.hasMessageContaining("Cannot publish submission in status: SUBMITTED");
+	}
+
+	@Test
+	void onboardPublisherAndManageTeamMembers() {
+		String ownerUserId = "user-owner-1";
+
+		// 1. Onboard Publisher Profile
+		OnboardPublisherRequest onboardReq = new OnboardPublisherRequest("HarperCollins", "contact@harper.example",
+				"payout_ref_harper_100");
+		PublisherResponse publisherRes = onboardingUseCase.onboardPublisher(onboardReq, ownerUserId);
+
+		assertThat(publisherRes.name()).isEqualTo("HarperCollins");
+		assertThat(publisherRes.contactEmail()).isEqualTo("contact@harper.example");
+		assertThat(publisherRes.payoutReference()).isEqualTo("payout_ref_harper_100");
+		assertThat(publisherRes.status()).isEqualTo("APPROVED");
+
+		// 2. Fetch User's Associated Publishers
+		List<PublisherResponse> myPublishers = onboardingUseCase.getPublishersForUser(ownerUserId);
+		assertThat(myPublishers).extracting(PublisherResponse::id).contains(publisherRes.id());
+
+		// 3. Add Team Member
+		AddPublisherMemberRequest memberReq = new AddPublisherMemberRequest("user-editor-2", "EDITOR");
+		PublisherMemberResponse memberRes = onboardingUseCase.addPublisherMember(publisherRes.id(), memberReq,
+				ownerUserId);
+		assertThat(memberRes.userId()).isEqualTo("user-editor-2");
+		assertThat(memberRes.role()).isEqualTo("EDITOR");
+
+		// 4. Update Publisher Profile
+		UpdatePublisherProfileRequest updateReq = new UpdatePublisherProfileRequest("HarperCollins Global",
+				"updated@harper.example", "payout_ref_harper_200");
+		PublisherResponse updated = onboardingUseCase.updatePublisherProfile(publisherRes.id(), updateReq, ownerUserId);
+		assertThat(updated.name()).isEqualTo("HarperCollins Global");
+		assertThat(updated.contactEmail()).isEqualTo("updated@harper.example");
+		assertThat(updated.payoutReference()).isEqualTo("payout_ref_harper_200");
+
+		// 5. Tenant Isolation / Authorization Enforcement
+		String unauthorizedUserId = "unauthorized-user-999";
+		assertThatThrownBy(() -> onboardingUseCase.getPublisherProfile(publisherRes.id(), unauthorizedUserId))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("unauthorized-user-999 is not authorized");
 	}
 
 }


### PR DESCRIPTION
Closes #13.

## Outcome
Allows approved publishers to manage identity, team member roles, payout references, and validated book metadata.

## Changes Made
- Added `V8__publisher_onboarding_schema.sql` Flyway migration for `payout_reference` and `publishing_publisher_members` table.
- Added `PublisherMemberEntity`, `PublisherMemberRole` (`OWNER`, `EDITOR`, `ADMIN`), and `PublisherMemberRepository`.
- Added `PublisherOnboardingUseCase` handling onboarding, profile updates, member management, and tenant isolation authorization.
- Added REST endpoints in `PublishingController` under `/api/v1/publishing/publishers/...`.
- Updated OpenAPI spec contract (`granthalay-api-v1.yaml`).
- Added integration tests (`PublishingIT`) covering onboarding, member addition, profile updates, and tenant isolation.